### PR TITLE
Add dockerized standalone download server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 .idea
 .vscode
 **/.env
-server/*
+server/node_modules/
+server/*.log
 server/.DS_Store
-server/**/*
 
 chrome_extension/dist
 chrome_extension/node_modules

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,23 @@
+# HTTP port exposed by the server
+PORT=8080
+
+# Maximum number of parallel downloads allowed
+MAX_CONCURRENT_DOWNLOADS=2
+
+# Absolute path inside the container where downloads will be written
+DOWNLOAD_DIR=/downloads
+
+# yt-dlp format selector. You can interpolate the quality marker with {quality}.
+DOWNLOAD_FORMAT=bestvideo+bestaudio/best
+
+# Optional quality limit (e.g. 1080p, 720p). Leave empty to download the best available quality.
+DOWNLOAD_QUALITY=1080p
+
+# File name template passed to yt-dlp
+OUTPUT_TEMPLATE=%(title)s.%(ext)s
+
+# Override when the yt-dlp binary lives in a non-standard path
+# YT_DLP_BINARY=/usr/local/bin/yt-dlp
+
+# Host directory that docker compose will mount to DOWNLOAD_DIR
+HOST_DOWNLOAD_DIR=./downloads

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    python3 \
+    python3-pip \
+  && pip3 install --no-cache-dir yt-dlp \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY src ./src
+COPY package.json ./
+
+ENV NODE_ENV=production
+
+EXPOSE 8080
+
+CMD ["node", "src/index.js"]

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,68 @@
+# DuckTracker Server
+
+This folder hosts a lightweight HTTP + WebSocket service that coordinates YouTube downloads for the DuckTracker extension. The service is designed to run inside Docker so it can be deployed independently from the Electron desktop app.
+
+## Features
+
+- **REST API** compatible with the Chrome extension (`/download`, `/stop_download`, `/downloads`, `/save_history`).
+- **WebSocket bridge** used to push live progress and completion events.
+- **Queue management** with an environment-configurable concurrency limit.
+- **Configurable output** path, quality, and format through environment variables.
+- **Docker-first workflow** with `docker-compose` for quick local or server deployments.
+
+## Getting Started
+
+1. Copy the sample environment file and tune it to your needs:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Key variables:
+
+   | Variable | Purpose |
+   | --- | --- |
+   | `PORT` | HTTP/WebSocket port to expose. |
+   | `MAX_CONCURRENT_DOWNLOADS` | How many downloads may run in parallel. |
+   | `DOWNLOAD_DIR` | Destination folder *inside* the container. |
+   | `DOWNLOAD_FORMAT` | `yt-dlp` format selector. Supports `{quality}` substitution. |
+   | `DOWNLOAD_QUALITY` | Optional resolution cap (e.g. `1080p`). |
+   | `OUTPUT_TEMPLATE` | File naming template passed to `yt-dlp`. |
+   | `HOST_DOWNLOAD_DIR` | (Compose only) Host folder that maps to the container's download directory. |
+
+2. Build and start the stack:
+
+   ```bash
+   docker compose up --build
+   ```
+
+   The default compose file exposes the server on `http://localhost:8080` and writes downloads into `./downloads` relative to this folder.
+
+3. Point the Chrome extension to the running instance. The WebSocket endpoint lives on the same port using `ws://localhost:PORT`.
+
+## API Summary
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/download` | Start (or queue) a new download. Body requires `url` and `urlId`. |
+| `POST` | `/stop_download` | Stop an active or queued download by `urlId`. |
+| `GET` | `/downloads` | Read the latest state for all known downloads. |
+| `POST` | `/save_history` | Acknowledge history sync events from the extension. |
+
+Responses always include CORS headers so the extension can call the endpoints directly from the browser environment.
+
+## Notes
+
+- The container bundles `yt-dlp` (via `pip`) and `ffmpeg` so no external dependencies are required.
+- `DOWNLOAD_FORMAT` recognises `{quality}` placeholders. For example, setting `DOWNLOAD_FORMAT=bestvideo[height<={quality}]+bestaudio/best[height<={quality}]` with `DOWNLOAD_QUALITY=1080p` restricts downloads to 1080p.
+- When the concurrency limit is reached the server queues incoming downloads and starts them automatically once a slot frees up.
+
+## Development
+
+To run the server without Docker you only need Node.js 20+ and `yt-dlp` available in your `PATH`:
+
+```bash
+PORT=8080 DOWNLOAD_DIR=./downloads node src/index.js
+```
+
+`node --watch src/index.js` provides a rudimentary dev loop.

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+
+services:
+  ducktracker-server:
+    build: .
+    container_name: ducktracker-server
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - PORT=${PORT:-8080}
+      - MAX_CONCURRENT_DOWNLOADS=${MAX_CONCURRENT_DOWNLOADS:-2}
+      - DOWNLOAD_DIR=${DOWNLOAD_DIR:-/downloads}
+      - DOWNLOAD_FORMAT=${DOWNLOAD_FORMAT:-bestvideo+bestaudio/best}
+      - DOWNLOAD_QUALITY=${DOWNLOAD_QUALITY:-}
+      - OUTPUT_TEMPLATE=${OUTPUT_TEMPLATE:-%(title)s.%(ext)s}
+    ports:
+      - "${PORT:-8080}:8080"
+    volumes:
+      - ${HOST_DOWNLOAD_DIR:-./downloads}:/downloads

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ducktracker-server",
+  "version": "1.0.0",
+  "description": "Lightweight download coordination server for DuckTracker",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "dev": "node --watch src/index.js"
+  },
+  "keywords": ["youtube", "downloader", "ducktracker"],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,64 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
+const DEFAULT_DOWNLOAD_DIR = '/downloads';
+const DEFAULT_FORMAT = 'bestvideo+bestaudio/best';
+const DEFAULT_TEMPLATE = '%(title)s.%(ext)s';
+
+function parseInteger(value, fallback) {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function normaliseQuality(input) {
+  if (!input) return null;
+  const match = /(?<height>\d{3,4})/u.exec(input);
+  if (!match || !match.groups) return null;
+  return Number.parseInt(match.groups.height, 10);
+}
+
+function buildFormat(baseFormat, qualityToken) {
+  if (!qualityToken) {
+    return baseFormat;
+  }
+
+  if (baseFormat && baseFormat.includes('{quality}')) {
+    return baseFormat.replace(/\{quality\}/gu, String(qualityToken));
+  }
+
+  const limit = `[height<=${qualityToken}]`;
+  return `bestvideo${limit}+bestaudio/best${limit}`;
+}
+
+function loadConfig() {
+  const rawDownloadDir = process.env.DOWNLOAD_DIR || DEFAULT_DOWNLOAD_DIR;
+  const downloadDir = path.resolve(rawDownloadDir);
+
+  const maxConcurrent = parseInteger(process.env.MAX_CONCURRENT_DOWNLOADS, 2);
+  const httpPort = parseInteger(process.env.PORT || process.env.HTTP_PORT, 8080);
+  const wsPath = process.env.WS_PATH || '/';
+
+  const qualityLimit = normaliseQuality(process.env.DOWNLOAD_QUALITY);
+  const format = buildFormat(process.env.DOWNLOAD_FORMAT || DEFAULT_FORMAT, qualityLimit);
+  const template = process.env.OUTPUT_TEMPLATE || DEFAULT_TEMPLATE;
+  const ytDlpBinary = process.env.YT_DLP_BINARY || 'yt-dlp';
+
+  const ensureDir = process.env.SKIP_DIR_CREATION !== 'true';
+  if (ensureDir) {
+    fs.mkdirSync(downloadDir, { recursive: true });
+  }
+
+  return {
+    downloadDir,
+    format,
+    template,
+    maxConcurrent,
+    httpPort,
+    wsPath,
+    ytDlpBinary,
+    qualityLimit
+  };
+}
+
+module.exports = { loadConfig };

--- a/server/src/download-manager.js
+++ b/server/src/download-manager.js
@@ -1,0 +1,220 @@
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const EventEmitter = require('node:events');
+const readline = require('node:readline');
+const fs = require('node:fs');
+
+function ensureDirectory(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+class DownloadManager extends EventEmitter {
+  constructor(config) {
+    super();
+    this.config = config;
+    this.activeDownloads = new Map();
+    this.queue = [];
+    this.state = new Map();
+  }
+
+  getStateList() {
+    return Array.from(this.state.values()).map((entry) => ({ ...entry }));
+  }
+
+  getState(urlId) {
+    return this.state.get(urlId);
+  }
+
+  enqueue(request) {
+    this.queue.push(request);
+    this.state.set(request.urlId, {
+      status: 'queued',
+      url: request.url,
+      urlId: request.urlId,
+      title: request.title || '',
+      percent: 0
+    });
+    this.emit('state', this.getState(request.urlId));
+  }
+
+  tryStart() {
+    while (this.activeDownloads.size < this.config.maxConcurrent && this.queue.length > 0) {
+      const next = this.queue.shift();
+      this.start(next);
+    }
+  }
+
+  start(request) {
+    if (this.activeDownloads.has(request.urlId)) {
+      return false;
+    }
+
+    ensureDirectory(this.config.downloadDir);
+
+    const ytArgs = this.buildArgs(request.url);
+    const child = spawn(this.config.ytDlpBinary, ytArgs, {
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    const downloadEntry = {
+      request,
+      child,
+      filePath: '',
+      stoppedManually: false
+    };
+
+    this.activeDownloads.set(request.urlId, downloadEntry);
+    const baseState = {
+      status: 'downloading',
+      url: request.url,
+      urlId: request.urlId,
+      title: request.title || '',
+      percent: 0
+    };
+    this.state.set(request.urlId, baseState);
+    this.emit('state', baseState);
+
+    const updateState = (partial) => {
+      const existing = this.state.get(request.urlId) || baseState;
+      const nextState = { ...existing, ...partial };
+      this.state.set(request.urlId, nextState);
+      this.emit('state', nextState);
+    };
+
+    const parseLine = (line) => {
+      if (!line) return;
+      const percentMatch = line.match(/(\d+(?:\.\d+)?)%/u);
+      if (percentMatch) {
+        updateState({ status: 'downloading', percent: Number.parseFloat(percentMatch[1]) });
+      }
+
+      const destMarker = 'Destination:';
+      if (line.includes(destMarker)) {
+        const candidate = line.slice(line.indexOf(destMarker) + destMarker.length).trim();
+        if (candidate) {
+          downloadEntry.filePath = candidate;
+        }
+      }
+
+      if (/has already been downloaded/u.test(line)) {
+        updateState({
+          status: 'completed',
+          percent: 100,
+          filePath: downloadEntry.filePath || this.deriveFilePath(request.title || request.urlId)
+        });
+        this.finish(request.urlId, 0);
+      }
+    };
+
+    const stdoutReader = readline.createInterface({ input: child.stdout });
+    stdoutReader.on('line', parseLine);
+    const stderrReader = readline.createInterface({ input: child.stderr });
+    stderrReader.on('line', parseLine);
+
+    child.on('error', (error) => {
+      updateState({ status: 'error', error: error.message });
+      this.cleanup(request.urlId);
+      this.tryStart();
+    });
+
+    child.on('close', (code) => {
+      stdoutReader.close();
+      stderrReader.close();
+
+      if (downloadEntry.stoppedManually) {
+        updateState({ status: 'stop', percent: 0 });
+        this.cleanup(request.urlId);
+        this.tryStart();
+        return;
+      }
+
+      if (code === 0) {
+        const finalPath = downloadEntry.filePath || this.deriveFilePath(request.title || request.urlId);
+        updateState({ status: 'completed', percent: 100, filePath: finalPath });
+        this.emit('finished', {
+          urlId: request.urlId,
+          url: request.url,
+          filePath: finalPath
+        });
+      } else {
+        updateState({ status: 'error', error: `yt-dlp exited with code ${code}` });
+      }
+
+      this.cleanup(request.urlId);
+      this.tryStart();
+    });
+
+    return true;
+  }
+
+  deriveFilePath(fallback) {
+    const safeName = fallback.replace(/[^a-z0-9\-_. ]+/giu, '_');
+    const outputName = this.config.template.replace('%(title)s', safeName).replace('%(ext)s', 'mp4');
+    return path.join(this.config.downloadDir, outputName);
+  }
+
+  buildArgs(url) {
+    const args = [
+      url,
+      '-P',
+      this.config.downloadDir,
+      '-o',
+      this.config.template,
+      '-f',
+      this.config.format,
+      '--newline'
+    ];
+
+    if (this.config.qualityLimit) {
+      args.push('--format-sort');
+      args.push(`res:${this.config.qualityLimit}`);
+    }
+
+    return args;
+  }
+
+  schedule(request) {
+    if (this.activeDownloads.size >= this.config.maxConcurrent) {
+      this.enqueue(request);
+      return { queued: true };
+    }
+
+    this.start(request);
+    return { queued: false };
+  }
+
+  stop(urlId) {
+    const active = this.activeDownloads.get(urlId);
+    if (active) {
+      active.stoppedManually = true;
+      active.child.kill('SIGTERM');
+      return true;
+    }
+
+    const queueIndex = this.queue.findIndex((item) => item.urlId === urlId);
+    if (queueIndex !== -1) {
+      const [entry] = this.queue.splice(queueIndex, 1);
+      this.state.set(urlId, {
+        status: 'stop',
+        url: entry.url,
+        urlId: entry.urlId,
+        title: entry.title || '',
+        percent: 0
+      });
+      this.emit('state', this.state.get(urlId));
+      return true;
+    }
+
+    return false;
+  }
+
+  cleanup(urlId) {
+    this.activeDownloads.delete(urlId);
+  }
+
+  finish(urlId) {
+    this.cleanup(urlId);
+  }
+}
+
+module.exports = { DownloadManager };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,203 @@
+const http = require('node:http');
+const url = require('node:url');
+const { loadConfig } = require('./config');
+const { DownloadManager } = require('./download-manager');
+const { handleUpgrade } = require('./websocket-server');
+
+const config = loadConfig();
+const downloadManager = new DownloadManager(config);
+const websocketClients = new Set();
+
+function jsonResponse(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+  res.end(body);
+}
+
+function handleOptions(req, res) {
+  res.writeHead(204, {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400'
+  });
+  res.end();
+}
+
+function collectRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let rawData = '';
+    req.on('data', (chunk) => {
+      rawData += chunk;
+      if (rawData.length > 5 * 1024 * 1024) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      if (!rawData) {
+        resolve({});
+        return;
+      }
+      try {
+        const parsed = JSON.parse(rawData);
+        resolve(parsed);
+      } catch (error) {
+        reject(new Error('Invalid JSON payload'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function broadcast(message) {
+  const payload = JSON.stringify(message);
+  for (const client of websocketClients) {
+    client.send(payload);
+  }
+}
+
+function handleWebSocketMessage(ws, rawMessage) {
+  try {
+    const parsed = JSON.parse(rawMessage);
+    if (parsed?.type === 'sync-history') {
+      // Echo back any missing entries request as empty payload for now.
+      ws.send(JSON.stringify({ type: 'sync-history', data: [] }));
+      return;
+    }
+  } catch (error) {
+    ws.send(JSON.stringify({ type: 'error', message: 'Invalid message payload' }));
+  }
+}
+
+downloadManager.on('state', (state) => {
+  broadcast({ type: 'download', payload: state });
+});
+
+downloadManager.on('finished', (info) => {
+  broadcast({ type: 'download-finished', payload: info });
+});
+
+function sendCurrentState(res) {
+  const list = downloadManager.getStateList();
+  jsonResponse(res, 200, list);
+}
+
+async function handleDownload(req, res) {
+  try {
+    const body = await collectRequestBody(req);
+    const { url: targetUrl, urlId, title } = body;
+    if (!targetUrl || !urlId) {
+      jsonResponse(res, 400, { error: 'url and urlId are required' });
+      return;
+    }
+
+    const existing = downloadManager.getState(urlId);
+    if (existing && ['downloading', 'queued'].includes(existing.status)) {
+      jsonResponse(res, 200, existing);
+      return;
+    }
+
+    const scheduleResult = downloadManager.schedule({ url: targetUrl, urlId, title: title || '' });
+    const updatedState = downloadManager.getState(urlId);
+    jsonResponse(res, 200, {
+      ...updatedState,
+      queued: scheduleResult.queued
+    });
+  } catch (error) {
+    jsonResponse(res, 500, { error: error.message });
+  }
+}
+
+async function handleStop(req, res) {
+  try {
+    const body = await collectRequestBody(req);
+    const { urlId } = body;
+    if (!urlId) {
+      jsonResponse(res, 400, { error: 'urlId is required' });
+      return;
+    }
+
+    const success = downloadManager.stop(urlId);
+    if (!success) {
+      jsonResponse(res, 404, { error: 'Download not found' });
+      return;
+    }
+
+    const state = downloadManager.getState(urlId);
+    jsonResponse(res, 200, state || { status: 'stop', urlId });
+  } catch (error) {
+    jsonResponse(res, 500, { error: error.message });
+  }
+}
+
+async function handleSaveHistory(req, res) {
+  try {
+    await collectRequestBody(req);
+    jsonResponse(res, 200, { success: true });
+  } catch (error) {
+    jsonResponse(res, 500, { error: error.message });
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url || '/', true);
+  if (req.method === 'OPTIONS') {
+    handleOptions(req, res);
+    return;
+  }
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/downloads') {
+    sendCurrentState(res);
+    return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/download') {
+    handleDownload(req, res);
+    return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/stop_download') {
+    handleStop(req, res);
+    return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/save_history') {
+    handleSaveHistory(req, res);
+    return;
+  }
+
+  jsonResponse(res, 404, { error: 'Not found' });
+});
+
+server.on('upgrade', (request, socket, head) => {
+  const ws = handleUpgrade(request, socket, head, websocketClients, config.wsPath);
+  if (ws) {
+    ws.on('message', (message) => handleWebSocketMessage(ws, message));
+  }
+});
+
+server.listen(config.httpPort, () => {
+  console.log(`[server] Listening on port ${config.httpPort}`);
+  console.log(`[server] Download directory: ${config.downloadDir}`);
+  console.log(`[server] Max concurrent downloads: ${config.maxConcurrent}`);
+  console.log(`[server] Format: ${config.format}`);
+  if (config.qualityLimit) {
+    console.log(`[server] Quality limit: ${config.qualityLimit}p`);
+  }
+});
+
+process.on('SIGINT', () => {
+  console.log('Received SIGINT, shutting down...');
+  server.close(() => process.exit(0));
+});
+
+process.on('SIGTERM', () => {
+  console.log('Received SIGTERM, shutting down...');
+  server.close(() => process.exit(0));
+});

--- a/server/src/websocket-server.js
+++ b/server/src/websocket-server.js
@@ -1,0 +1,205 @@
+const crypto = require('node:crypto');
+const EventEmitter = require('node:events');
+
+const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+class SimpleWebSocket extends EventEmitter {
+  constructor(socket) {
+    super();
+    this.socket = socket;
+    this.buffer = Buffer.alloc(0);
+    this.alive = true;
+
+    socket.on('data', (chunk) => this.handleData(chunk));
+    socket.on('close', () => this.handleClose());
+    socket.on('end', () => this.handleClose());
+    socket.on('error', (error) => this.emit('error', error));
+  }
+
+  handleClose() {
+    if (!this.alive) return;
+    this.alive = false;
+    this.emit('close');
+  }
+
+  send(data) {
+    if (!this.alive) return;
+    const payload = Buffer.isBuffer(data) ? data : Buffer.from(String(data));
+    const frame = this.createFrame(payload);
+    this.socket.write(frame);
+  }
+
+  createFrame(payload) {
+    const payloadLength = payload.length;
+    let headerLength = 2;
+    if (payloadLength >= 126 && payloadLength <= 0xffff) {
+      headerLength += 2;
+    } else if (payloadLength > 0xffff) {
+      headerLength += 8;
+    }
+
+    const frame = Buffer.alloc(headerLength + payloadLength);
+    frame[0] = 0x81; // FIN + text frame
+
+    let offset = 2;
+    if (payloadLength < 126) {
+      frame[1] = payloadLength;
+    } else if (payloadLength <= 0xffff) {
+      frame[1] = 126;
+      frame.writeUInt16BE(payloadLength, offset);
+      offset += 2;
+    } else {
+      frame[1] = 127;
+      frame.writeBigUInt64BE(BigInt(payloadLength), offset);
+      offset += 8;
+    }
+
+    payload.copy(frame, offset);
+    return frame;
+  }
+
+  handleData(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (this.buffer.length >= 2) {
+      const firstByte = this.buffer[0];
+      const secondByte = this.buffer[1];
+
+      const fin = (firstByte & 0x80) !== 0;
+      const opcode = firstByte & 0x0f;
+      const masked = (secondByte & 0x80) !== 0;
+      let payloadLength = secondByte & 0x7f;
+      let headerLength = 2;
+
+      if (payloadLength === 126) {
+        if (this.buffer.length < 4) return;
+        payloadLength = this.buffer.readUInt16BE(2);
+        headerLength = 4;
+      } else if (payloadLength === 127) {
+        if (this.buffer.length < 10) return;
+        const lengthBig = this.buffer.readBigUInt64BE(2);
+        if (lengthBig > BigInt(Number.MAX_SAFE_INTEGER)) {
+          this.close();
+          return;
+        }
+        payloadLength = Number(lengthBig);
+        headerLength = 10;
+      }
+
+      const maskOffset = headerLength;
+      const totalLength = headerLength + (masked ? 4 : 0) + payloadLength;
+      if (this.buffer.length < totalLength) {
+        return;
+      }
+
+      let payloadStart = headerLength;
+      let payload = this.buffer.slice(payloadStart, payloadStart + payloadLength);
+
+      if (masked) {
+        const mask = this.buffer.slice(maskOffset, maskOffset + 4);
+        payloadStart += 4;
+        payload = this.buffer.slice(payloadStart, payloadStart + payloadLength);
+        for (let i = 0; i < payload.length; i += 1) {
+          payload[i] ^= mask[i % 4];
+        }
+      }
+
+      this.buffer = this.buffer.slice(totalLength);
+
+      if (!fin) {
+        // Fragmented frames are not supported
+        continue;
+      }
+
+      if (opcode === 0x8) {
+        this.close();
+        return;
+      }
+
+      if (opcode === 0x9) {
+        // ping
+        this.sendPong(payload);
+        continue;
+      }
+
+      if (opcode === 0xA) {
+        continue;
+      }
+
+      if (opcode === 0x1) {
+        try {
+          const message = payload.toString('utf8');
+          this.emit('message', message);
+        } catch (error) {
+          this.emit('error', error);
+        }
+      }
+    }
+  }
+
+  sendPong(payload) {
+    if (!this.alive) return;
+    const frame = Buffer.alloc(2 + payload.length);
+    frame[0] = 0x8A; // FIN + pong
+    frame[1] = payload.length;
+    if (payload.length > 0) {
+      payload.copy(frame, 2);
+    }
+    this.socket.write(frame);
+  }
+
+  close() {
+    if (!this.alive) return;
+    this.alive = false;
+    try {
+      this.socket.end(Buffer.from([0x88, 0x00]));
+    } catch (error) {
+      this.socket.destroy();
+    }
+    this.emit('close');
+  }
+}
+
+function handleUpgrade(request, socket, head, clients, pathFilter) {
+  if (request.headers.upgrade?.toLowerCase() !== 'websocket') {
+    socket.destroy();
+    return;
+  }
+
+  const requestUrl = new URL(request.url, `http://${request.headers.host}`);
+  if (pathFilter && requestUrl.pathname !== pathFilter) {
+    socket.destroy();
+    return;
+  }
+
+  const acceptKey = request.headers['sec-websocket-key'];
+  if (!acceptKey) {
+    socket.destroy();
+    return;
+  }
+
+  const hash = crypto
+    .createHash('sha1')
+    .update(acceptKey + GUID)
+    .digest('base64');
+
+  const headers = [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${hash}`,
+    '\r\n'
+  ];
+
+  socket.write(headers.join('\r\n'));
+
+  const ws = new SimpleWebSocket(socket);
+  clients.add(ws);
+  ws.on('close', () => {
+    clients.delete(ws);
+  });
+
+  ws.emit('open');
+  return ws;
+}
+
+module.exports = { SimpleWebSocket, handleUpgrade };


### PR DESCRIPTION
## Summary
- add a minimal Node.js HTTP/WebSocket service under `server/` that mirrors the Chrome extension API
- wire download queue management to yt-dlp with configurable concurrency, format, quality, and output location via env vars
- provide Dockerfile, docker-compose setup, and documentation for running the server in an isolated container

## Testing
- node --check src/index.js
- node --check src/download-manager.js
- node --check src/websocket-server.js
- node --check src/config.js

------
https://chatgpt.com/codex/tasks/task_e_68d4ca1fdd408326ad449c2a999c6085