### PR TITLE
Enhance history page download management

### DIFF
--- a/server/src/database.js
+++ b/server/src/database.js
@@ -32,6 +32,12 @@ function ensureStatements(db) {
           updated_at = CURRENT_TIMESTAMP
       WHERE url_id = @urlId
     `),
+    setFilePath: db.prepare(`
+      UPDATE downloads
+      SET file_path = @filePath,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE url_id = @urlId
+    `),
     setTitle: db.prepare(`
       UPDATE downloads
       SET title = @title,
@@ -40,7 +46,7 @@ function ensureStatements(db) {
     `),
     selectAllIds: db.prepare('SELECT url_id FROM downloads'),
     selectState: db.prepare(`
-      SELECT url_id AS urlId, url, title, status, last_error AS lastError
+      SELECT url_id AS urlId, url, title, status, last_error AS lastError, file_path AS filePath
       FROM downloads
       WHERE url_id = ?
     `)
@@ -65,11 +71,18 @@ function initDatabase(dbPath) {
       status TEXT NOT NULL,
       last_error TEXT,
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      file_path TEXT DEFAULT ''
     );
 
     CREATE INDEX IF NOT EXISTS idx_downloads_status ON downloads(status);
   `);
+
+  const columns = instance.prepare('PRAGMA table_info(downloads)').all();
+  const hasFilePath = columns.some((column) => column.name === 'file_path');
+  if (!hasFilePath) {
+    instance.exec('ALTER TABLE downloads ADD COLUMN file_path TEXT DEFAULT "";');
+  }
 
   ensureStatements(instance);
 
@@ -120,6 +133,9 @@ function recordDownloadCompleted(payload) {
     status: 'completed',
     lastError: null
   });
+  if (payload.filePath) {
+    stmts.setFilePath.run({ urlId: payload.urlId, filePath: payload.filePath });
+  }
 }
 
 function recordDownloadTitle(payload) {
@@ -136,6 +152,23 @@ function recordDownloadTitle(payload) {
   stmts.setTitle.run({
     urlId: payload.urlId,
     title: payload.title
+  });
+}
+
+function recordDownloadFilePath(payload) {
+  const db = instance;
+  if (!db) {
+    throw new Error('Database not initialised');
+  }
+
+  if (!payload.filePath) {
+    return;
+  }
+
+  const stmts = ensureStatements(db);
+  stmts.setFilePath.run({
+    urlId: payload.urlId,
+    filePath: payload.filePath
   });
 }
 
@@ -211,6 +244,41 @@ function getDownloadState(urlId) {
   return stmts.selectState.get(urlId) || null;
 }
 
+function deleteDownloads(urlIds) {
+  const db = instance;
+  if (!db) {
+    throw new Error('Database not initialised');
+  }
+
+  if (!Array.isArray(urlIds) || urlIds.length === 0) {
+    return [];
+  }
+
+  const uniqueIds = Array.from(new Set(urlIds.filter((id) => typeof id === 'string' && id.trim())));
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const placeholders = uniqueIds.map(() => '?').join(',');
+  const selectStmt = db.prepare(`
+    SELECT url_id AS urlId, file_path AS filePath
+    FROM downloads
+    WHERE url_id IN (${placeholders})
+  `);
+  const deleteStmt = db.prepare(`
+    DELETE FROM downloads
+    WHERE url_id IN (${placeholders})
+  `);
+
+  const transaction = db.transaction((ids) => {
+    const rows = selectStmt.all(...ids);
+    deleteStmt.run(...ids);
+    return rows;
+  });
+
+  return transaction(uniqueIds);
+}
+
 function searchDownloads({ searchTerm = '', page = 1, pageSize = 20 }) {
   const db = instance;
   if (!db) {
@@ -246,7 +314,8 @@ function searchDownloads({ searchTerm = '', page = 1, pageSize = 20 }) {
       status,
       last_error AS lastError,
       created_at AS createdAt,
-      updated_at AS updatedAt
+      updated_at AS updatedAt,
+      file_path AS filePath
     FROM downloads
     ${whereClause}
     ORDER BY datetime(created_at) DESC, datetime(updated_at) DESC
@@ -274,5 +343,7 @@ module.exports = {
   ensureUrlIds,
   collectServerOnlyUrlIds,
   getDownloadState,
-  searchDownloads
+  searchDownloads,
+  recordDownloadFilePath,
+  deleteDownloads
 };

--- a/server/src/download-manager.js
+++ b/server/src/download-manager.js
@@ -9,7 +9,8 @@ const {
   recordDownloadCompleted,
   recordDownloadError,
   recordDownloadStopped,
-  recordDownloadTitle
+  recordDownloadTitle,
+  recordDownloadFilePath
 } = require('./database');
 
 function ensureDirectory(dirPath) {
@@ -154,18 +155,14 @@ class DownloadManager extends EventEmitter {
         if (candidate) {
           downloadEntry.filePath = candidate;
           captureResolvedTitle(this.deriveTitleFromPath(candidate));
+          recordDownloadFilePath({ urlId: request.urlId, filePath: candidate });
         }
       }
 
       if (/has already been downloaded/u.test(line)) {
         const inferredPath = downloadEntry.filePath || this.deriveFilePath(request.title || request.urlId);
         captureResolvedTitle(downloadEntry.resolvedTitle || this.deriveTitleFromPath(inferredPath));
-        // updateState({
-        //   status: 'completed',
-        //   percent: 100,
-        //   filePath: inferredPath,
-        //   title: downloadEntry.resolvedTitle
-        // });
+        recordDownloadFilePath({ urlId: request.urlId, filePath: inferredPath });
         emitFinished({ status: 'completed', percent: 100, filePath: inferredPath, title: downloadEntry.resolvedTitle });
         this.finish(request.urlId);
       }
@@ -216,7 +213,7 @@ class DownloadManager extends EventEmitter {
         const finalTitle = downloadEntry.resolvedTitle || this.deriveTitleFromPath(finalPath);
         captureResolvedTitle(finalTitle);
         // updateState({ status: 'completed', percent: 100, filePath: finalPath, title: downloadEntry.resolvedTitle, error: undefined });
-        recordDownloadCompleted({ urlId: request.urlId, url: request.url });
+        recordDownloadCompleted({ urlId: request.urlId, url: request.url, filePath: finalPath });
         emitFinished({ percent: 100, status: 'completed', filePath: finalPath, title: downloadEntry.resolvedTitle, error: undefined });
       } else {
         const errorMessage = `yt-dlp exited with code ${code}`;

--- a/server/src/history-page.js
+++ b/server/src/history-page.js
@@ -39,15 +39,57 @@ function renderTableRows(items) {
       const lastError = escapeHtml(item.lastError || '');
       const createdAt = escapeHtml(item.createdAt || '');
       const updatedAt = escapeHtml(item.updatedAt || '');
+      const fileAvailable = Boolean(item.filePath);
+      const sourceUrl = escapeHtml(item.url || '');
+      const urlDisplay = sourceUrl || urlId || '';
+
+      const statusClass = `status-badge status-${status}`;
+      const statusLabel = status;
+
+      const downloadDisabled = !fileAvailable || status !== 'completed';
+      const downloadTitle = downloadDisabled
+        ? '완료된 항목만 다운로드할 수 있습니다.'
+        : '파일 다운로드';
 
       return `
-        <tr>
-          <td class="title">${title}</td>
-          <td class="url-id">${urlId}</td>
-          <td class="status">${status}</td>
-          <td class="error">${lastError}</td>
-          <td class="created">${createdAt}</td>
-          <td class="updated">${updatedAt}</td>
+        <tr data-url-id="${urlId}">
+          <td class="title" data-label="제목">
+            <div class="title-text" title="${title || '(제목 없음)'}">${title || '<span class="muted">(제목 없음)</span>'}</div>
+            <div class="title-url" title="${urlDisplay}">
+              ${sourceUrl ? `<a href="${sourceUrl}" target="_blank" rel="noopener noreferrer">${urlDisplay}</a>` : urlDisplay || '<span class="muted">-</span>'}
+            </div>
+          </td>
+          <td class="status" data-label="상태">
+            <span class="${statusClass}">${statusLabel}</span>
+          </td>
+          <td class="error" data-label="오류">
+            ${lastError ? `<span title="${lastError}">${lastError}</span>` : '<span class="muted">-</span>'}
+          </td>
+          <td class="created" data-label="생성일">${createdAt || '-'}</td>
+          <td class="updated" data-label="업데이트">${updatedAt || '-'}</td>
+          <td class="actions" data-label="작업">
+            <button
+              class="icon-button download-button"
+              data-url-id="${urlId}"
+              ${downloadDisabled ? 'disabled' : ''}
+              title="${downloadTitle}"
+              aria-label="${downloadTitle}"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M5 20h14v-2H5v2zm7-18l-5.5 6h3.5v6h4v-6H17L12 2z" />
+              </svg>
+            </button>
+            <button
+              class="icon-button delete-button"
+              data-url-id="${urlId}"
+              title="이력 삭제"
+              aria-label="이력 삭제"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" />
+              </svg>
+            </button>
+          </td>
         </tr>
       `;
     })
@@ -107,36 +149,55 @@ function renderHistoryPage({
         padding: 24px;
         box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
       }
-      form {
+      .toolbar {
         display: flex;
         flex-wrap: wrap;
         gap: 12px;
+        justify-content: space-between;
+        align-items: stretch;
         margin-bottom: 20px;
-        align-items: center;
       }
-      label {
-        font-weight: 600;
-      }
-      input[type="text"] {
+      .search-form {
+        display: flex;
         flex: 1;
-        min-width: 240px;
+        gap: 12px;
+        min-width: 260px;
+      }
+      .search-form input[type="text"] {
+        flex: 1;
         padding: 10px 14px;
         border-radius: 10px;
         border: 1px solid #d0d7de;
         font-size: 1rem;
       }
+      .toolbar-actions {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
       button {
         padding: 10px 18px;
-        border: none;
         border-radius: 10px;
-        background: #2563eb;
-        color: white;
         font-weight: 600;
         cursor: pointer;
-        transition: background 0.2s ease;
+        transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        border: none;
       }
-      button:hover {
+      button.primary {
+        background: #2563eb;
+        color: white;
+      }
+      button.primary:hover {
         background: #1d4ed8;
+      }
+      button.secondary {
+        background: white;
+        color: #1f2937;
+        border: 1px solid #cbd5f5;
+      }
+      button.secondary:hover {
+        background: #eff6ff;
       }
       table {
         width: 100%;
@@ -160,11 +221,95 @@ function renderHistoryPage({
       tbody tr:hover {
         background: rgba(37, 99, 235, 0.15);
       }
+      .actions-column {
+        text-align: center;
+        width: 120px;
+      }
       .empty-row td {
         text-align: center;
         padding: 24px 12px;
         color: #6b7280;
         font-style: italic;
+      }
+      .status-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        border-radius: 999px;
+        padding: 4px 10px;
+        font-size: 0.85rem;
+        font-weight: 600;
+        text-transform: capitalize;
+        background: #e2e8f0;
+        color: #0f172a;
+      }
+      .status-completed {
+        background: #dcfce7;
+        color: #166534;
+      }
+      .status-downloading {
+        background: #dbeafe;
+        color: #1e3a8a;
+      }
+      .status-error, .status-failed {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+      .status-queued, .status-pending {
+        background: #fef3c7;
+        color: #92400e;
+      }
+      .icon-button {
+        border: none;
+        background: transparent;
+        padding: 6px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+      .icon-button svg {
+        width: 20px;
+        height: 20px;
+        fill: currentColor;
+      }
+      .icon-button.download-button {
+        color: #2563eb;
+      }
+      .icon-button.delete-button {
+        color: #dc2626;
+      }
+      .icon-button:hover:not([disabled]) {
+        background: rgba(37, 99, 235, 0.12);
+        transform: translateY(-1px);
+      }
+      .icon-button[disabled] {
+        color: #9ca3af;
+        cursor: not-allowed;
+        opacity: 0.7;
+      }
+      .title-text {
+        font-weight: 600;
+        margin-bottom: 4px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .title-url {
+        font-size: 0.85rem;
+        color: #64748b;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .title-url a {
+        color: inherit;
+        text-decoration: underline;
+      }
+      .muted {
+        color: #94a3b8;
       }
       .summary {
         display: flex;
@@ -205,16 +350,120 @@ function renderHistoryPage({
         cursor: not-allowed;
         background: #f8fafc;
       }
+      .dialog-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.45);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        opacity: 0;
+        transition: opacity 0.2s ease;
+      }
+      .dialog-backdrop.visible {
+        opacity: 1;
+      }
+      .dialog {
+        background: #fff;
+        border-radius: 16px;
+        padding: 24px;
+        max-width: 400px;
+        width: 92%;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.2);
+      }
+      .dialog h2 {
+        margin-top: 0;
+        margin-bottom: 8px;
+      }
+      .dialog form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .dialog input[type="url"] {
+        padding: 12px 14px;
+        border-radius: 10px;
+        border: 1px solid #d1d5db;
+        font-size: 1rem;
+      }
+      .dialog-buttons {
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+        margin-top: 8px;
+      }
+      .form-helper {
+        color: #dc2626;
+        font-size: 0.85rem;
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
       @media (max-width: 768px) {
-        table {
-          display: block;
-          overflow-x: auto;
-        }
-        th, td {
-          white-space: nowrap;
-        }
         .card {
           padding: 16px;
+        }
+        .toolbar {
+          flex-direction: column;
+          align-items: stretch;
+        }
+        .toolbar-actions {
+          justify-content: stretch;
+        }
+        .toolbar-actions button {
+          flex: 1;
+        }
+        table, thead, tbody, th, tr, td {
+          display: block;
+        }
+        thead {
+          clip: rect(0 0 0 0);
+          height: 1px;
+          width: 1px;
+          overflow: hidden;
+          position: absolute;
+        }
+        tbody tr {
+          background: #fff;
+          border-radius: 12px;
+          box-shadow: 0 8px 22px rgba(15, 23, 42, 0.12);
+          margin-bottom: 16px;
+          padding: 16px;
+        }
+        td {
+          display: flex;
+          justify-content: space-between;
+          gap: 16px;
+          padding: 10px 0;
+        }
+        td::before {
+          content: attr(data-label);
+          font-weight: 600;
+          color: #475569;
+        }
+        .actions {
+          justify-content: flex-start;
+          gap: 12px;
+        }
+        .actions::before {
+          align-self: center;
+        }
+        .title-text, .title-url {
+          white-space: normal;
+        }
+        .summary {
+          align-items: flex-start;
+          flex-direction: column;
+          gap: 8px;
         }
       }
     </style>
@@ -222,26 +471,33 @@ function renderHistoryPage({
   <body>
     <div class="card">
       <h1>다운로드 이력</h1>
-      <form method="GET" action="/history">
-        <label for="search">URL ID 또는 제목 검색</label>
-        <input
-          type="text"
-          id="search"
-          name="search"
-          placeholder="검색어를 입력하세요"
-          value="${escapeHtml(searchTerm || '')}"
-        />
-        <button type="submit">검색</button>
-      </form>
+      <div class="toolbar">
+        <form method="GET" action="/history" class="search-form">
+          <label for="search" class="visually-hidden">URL ID 또는 제목 검색</label>
+          <input
+            type="text"
+            id="search"
+            name="search"
+            placeholder="URL ID 또는 제목 검색"
+            value="${escapeHtml(searchTerm || '')}"
+            aria-label="URL ID 또는 제목 검색"
+          />
+          <button type="submit" class="primary">검색</button>
+        </form>
+        <div class="toolbar-actions">
+          <button type="button" class="secondary" data-action="refresh">새로고침</button>
+          <button type="button" class="primary" data-action="open-add-dialog">다운로드 추가</button>
+        </div>
+      </div>
       <table>
         <thead>
           <tr>
-            <th>제목</th>
-            <th>URL ID</th>
+            <th>제목 / URL ID</th>
             <th>상태</th>
             <th>오류</th>
             <th>생성일</th>
             <th>업데이트</th>
+            <th class="actions-column">작업</th>
           </tr>
         </thead>
         <tbody>
@@ -257,6 +513,175 @@ function renderHistoryPage({
         </div>
       </div>
     </div>
+    <div class="dialog-backdrop" data-dialog="add-download" hidden>
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="add-download-title">
+        <h2 id="add-download-title">다운로드 추가</h2>
+        <p>다운로드할 영상의 URL을 입력하세요.</p>
+        <form data-form="add-download">
+          <label for="download-url" class="visually-hidden">다운로드 URL</label>
+          <input type="url" id="download-url" name="url" placeholder="https://" required />
+          <p class="form-helper" data-error-message hidden>유효한 URL을 입력해주세요.</p>
+          <div class="dialog-buttons">
+            <button type="button" class="secondary" data-action="cancel-dialog">취소</button>
+            <button type="submit" class="primary">다운로드 요청</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    <script>
+      (function() {
+        const backdrop = document.querySelector('[data-dialog="add-download"]');
+        const form = backdrop ? backdrop.querySelector('form[data-form="add-download"]') : null;
+        const urlInput = form ? form.querySelector('input[name="url"]') : null;
+        const errorMessage = form ? form.querySelector('[data-error-message]') : null;
+
+        function openDialog() {
+          if (!backdrop) return;
+          backdrop.hidden = false;
+          requestAnimationFrame(() => {
+            backdrop.classList.add('visible');
+            if (urlInput) {
+              urlInput.value = '';
+              urlInput.focus();
+            }
+            if (errorMessage) {
+              errorMessage.hidden = true;
+            }
+          });
+        }
+
+        function closeDialog() {
+          if (!backdrop) return;
+          backdrop.classList.remove('visible');
+          setTimeout(() => {
+            backdrop.hidden = true;
+          }, 150);
+        }
+
+        function validateUrl(value) {
+          try {
+            const parsed = new URL(value);
+            return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+          } catch (error) {
+            return false;
+          }
+        }
+
+        function deriveUrlId(value) {
+          try {
+            const parsed = new URL(value);
+            if (parsed.searchParams.has('list')) {
+              return parsed.searchParams.get('list');
+            }
+            const pathname = parsed.pathname || '';
+            const shortsMatch = pathname.match(/\\/shorts\\/([a-zA-Z0-9_-]{11})/u);
+            if (shortsMatch && shortsMatch[1]) {
+              return shortsMatch[1];
+            }
+            const watchId = parsed.searchParams.get('v');
+            if (watchId) {
+              return watchId;
+            }
+            if (parsed.hostname === 'youtu.be') {
+              const [, id] = pathname.split('/');
+              if (id) {
+                return id;
+              }
+            }
+            return parsed.href;
+          } catch (error) {
+            return '';
+          }
+        }
+
+        const openButton = document.querySelector('[data-action="open-add-dialog"]');
+        openButton?.addEventListener('click', openDialog);
+
+        const refreshButton = document.querySelector('[data-action="refresh"]');
+        refreshButton?.addEventListener('click', () => {
+          window.location.reload();
+        });
+
+        backdrop?.addEventListener('click', (event) => {
+          if (event.target === backdrop) {
+            closeDialog();
+          }
+        });
+
+        const cancelButton = backdrop ? backdrop.querySelector('[data-action="cancel-dialog"]') : null;
+        cancelButton?.addEventListener('click', closeDialog);
+
+        form?.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          if (!urlInput) return;
+          const value = urlInput.value.trim();
+          if (!validateUrl(value)) {
+            if (errorMessage) {
+              errorMessage.hidden = false;
+            }
+            urlInput.focus();
+            return;
+          }
+
+          if (errorMessage) {
+            errorMessage.hidden = true;
+          }
+
+          try {
+            const response = await fetch('/history/request-download', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ url: value, urlId: deriveUrlId(value) })
+            });
+
+            if (!response.ok) {
+              const data = await response.json().catch(() => ({ }));
+              alert(data.error || '다운로드 요청에 실패했습니다.');
+              return;
+            }
+
+            closeDialog();
+            window.location.reload();
+          } catch (error) {
+            alert('다운로드 요청 중 오류가 발생했습니다.');
+          }
+        });
+
+        document.querySelectorAll('.delete-button').forEach((button) => {
+          button.addEventListener('click', async () => {
+            const urlId = button.dataset.urlId;
+            if (!urlId) return;
+            const confirmed = window.confirm('정말로 이 다운로드 이력을 삭제하시겠습니까? 파일도 함께 삭제됩니다.');
+            if (!confirmed) {
+              return;
+            }
+
+            try {
+              const response = await fetch(`/history/${encodeURIComponent(urlId)}`, { method: 'DELETE' });
+              if (!response.ok) {
+                const data = await response.json().catch(() => ({ }));
+                alert(data.error || '삭제에 실패했습니다.');
+                return;
+              }
+              window.location.reload();
+            } catch (error) {
+              alert('삭제 중 오류가 발생했습니다.');
+            }
+          });
+        });
+
+        document.querySelectorAll('.download-button').forEach((button) => {
+          button.addEventListener('click', () => {
+            if (button.disabled) {
+              return;
+            }
+            const urlId = button.dataset.urlId;
+            if (!urlId) return;
+            window.location.href = `/history/${encodeURIComponent(urlId)}/file`;
+          });
+        });
+      })();
+    </script>
   </body>
   </html>`;
 }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,5 +1,7 @@
 const http = require('node:http');
 const url = require('node:url');
+const fs = require('node:fs');
+const path = require('node:path');
 const { loadConfig } = require('./config');
 const { DownloadManager } = require('./download-manager');
 const { handleUpgrade } = require('./websocket-server');
@@ -7,7 +9,9 @@ const {
   initDatabase,
   ensureUrlIds,
   collectServerOnlyUrlIds,
-  searchDownloads
+  searchDownloads,
+  getDownloadState,
+  deleteDownloads
 } = require('./database');
 const { renderHistoryPage } = require('./history-page');
 
@@ -77,6 +81,49 @@ function broadcast(message) {
   }
 }
 
+function isPathInside(baseDir, candidatePath) {
+  const relative = path.relative(baseDir, candidatePath);
+  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function isValidUrl(candidate) {
+  try {
+    const parsed = new URL(candidate);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch (error) {
+    return false;
+  }
+}
+
+function deriveUrlIdFromUrl(targetUrl) {
+  try {
+    const parsed = new URL(targetUrl);
+    if (parsed.searchParams.has('list')) {
+      return parsed.searchParams.get('list');
+    }
+
+    const pathname = parsed.pathname || '';
+    const shortsMatch = pathname.match(/\/shorts\/([a-zA-Z0-9_-]{11})/u);
+    if (shortsMatch && shortsMatch[1]) {
+      return shortsMatch[1];
+    }
+
+    const watchId = parsed.searchParams.get('v');
+    if (watchId) {
+      return watchId;
+    }
+
+    const youtuMatch = pathname.match(/\/([a-zA-Z0-9_-]{11})$/u);
+    if (parsed.hostname === 'youtu.be' && youtuMatch && youtuMatch[1]) {
+      return youtuMatch[1];
+    }
+
+    return parsed.href;
+  } catch (error) {
+    return null;
+  }
+}
+
 function handleWebSocketMessage(ws, rawMessage) {
   try {
     const parsed = JSON.parse(rawMessage);
@@ -131,6 +178,134 @@ async function handleDownload(req, res) {
     });
   } catch (error) {
     jsonResponse(res, 500,  { error: error.message });
+  }
+}
+
+async function handleHistoryDownloadRequest(req, res) {
+  try {
+    const body = await collectRequestBody(req);
+    const { url: targetUrl } = body;
+
+    if (!targetUrl || typeof targetUrl !== 'string' || !isValidUrl(targetUrl)) {
+      jsonResponse(res, 400, { error: 'A valid URL is required.' });
+      return;
+    }
+
+    const derivedId = deriveUrlIdFromUrl(targetUrl);
+    if (!derivedId) {
+      jsonResponse(res, 400, { error: 'Could not determine URL identifier.' });
+      return;
+    }
+
+    const existing = downloadManager.getState(derivedId);
+    if (existing && ['downloading', 'queued'].includes(existing.status)) {
+      jsonResponse(res, 200, existing);
+      return;
+    }
+
+    const scheduleResult = downloadManager.schedule({ url: targetUrl, urlId: derivedId, title: '' });
+    const updatedState = downloadManager.getState(derivedId) || {
+      url: targetUrl,
+      urlId: derivedId,
+      status: scheduleResult.queued ? 'queued' : 'downloading',
+      percent: 0
+    };
+    jsonResponse(res, 200, {
+      ...updatedState,
+      queued: scheduleResult.queued
+    });
+  } catch (error) {
+    jsonResponse(res, 500, { error: error.message });
+  }
+}
+
+async function handleHistoryDelete(req, res, urlId) {
+  try {
+    if (!urlId) {
+      jsonResponse(res, 400, { error: 'urlId is required' });
+      return;
+    }
+
+    const existingState = downloadManager.getState(urlId);
+    if (existingState && ['downloading', 'queued'].includes(existingState.status)) {
+      downloadManager.stop(urlId);
+    }
+
+    const deleted = deleteDownloads([urlId]);
+    if (!deleted || deleted.length === 0) {
+      jsonResponse(res, 404, { error: 'Record not found' });
+      return;
+    }
+
+    const results = await Promise.all(deleted.map(async ({ filePath, urlId: deletedId }) => {
+      if (!filePath) {
+        return { urlId: deletedId, fileRemoved: false };
+      }
+
+      const resolved = path.resolve(filePath);
+      if (!isPathInside(config.downloadDir, resolved)) {
+        return { urlId: deletedId, fileRemoved: false, reason: 'outside-download-dir' };
+      }
+
+      try {
+        await fs.promises.unlink(resolved);
+        return { urlId: deletedId, fileRemoved: true };
+      } catch (error) {
+        if (error && error.code === 'ENOENT') {
+          return { urlId: deletedId, fileRemoved: false, reason: 'not-found' };
+        }
+        return { urlId: deletedId, fileRemoved: false, reason: 'unlink-failed' };
+      }
+    }));
+
+    jsonResponse(res, 200, { success: true, results });
+  } catch (error) {
+    jsonResponse(res, 500, { error: error.message });
+  }
+}
+
+function handleHistoryFileDownload(req, res, urlId) {
+  try {
+    if (!urlId) {
+      jsonResponse(res, 400, { error: 'urlId is required' });
+      return;
+    }
+
+    const record = getDownloadState(urlId);
+    if (!record || !record.filePath) {
+      jsonResponse(res, 404, { error: 'File not available' });
+      return;
+    }
+
+    const resolved = path.resolve(record.filePath);
+    if (!isPathInside(config.downloadDir, resolved)) {
+      jsonResponse(res, 403, { error: 'File outside of download directory' });
+      return;
+    }
+
+    fs.stat(resolved, (statError, stats) => {
+      if (statError) {
+        jsonResponse(res, statError.code === 'ENOENT' ? 404 : 500, { error: 'File not found' });
+        return;
+      }
+
+      res.writeHead(200, {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': stats.size,
+        'Content-Disposition': `attachment; filename="${encodeURIComponent(path.basename(resolved))}"`
+      });
+
+      const stream = fs.createReadStream(resolved);
+      stream.on('error', () => {
+        if (!res.headersSent) {
+          res.writeHead(500);
+        }
+        res.end();
+      });
+      stream.pipe(res);
+    });
+  } catch (error) {
+    jsonResponse(res, 500, { error: error.message });
   }
 }
 
@@ -208,6 +383,27 @@ const server = http.createServer((req, res) => {
   if (req.method === 'GET' && parsedUrl.pathname === '/history') {
     handleHistory(req, res, parsedUrl.query || {});
     return;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/history/request-download') {
+    handleHistoryDownloadRequest(req, res);
+    return;
+  }
+
+  if (req.method === 'DELETE' && parsedUrl.pathname && parsedUrl.pathname.startsWith('/history/')) {
+    const segments = parsedUrl.pathname.split('/').filter(Boolean);
+    if (segments.length === 2) {
+      handleHistoryDelete(req, res, decodeURIComponent(segments[1]));
+      return;
+    }
+  }
+
+  if (req.method === 'GET' && parsedUrl.pathname && parsedUrl.pathname.startsWith('/history/')) {
+    const segments = parsedUrl.pathname.split('/').filter(Boolean);
+    if (segments.length === 3 && segments[2] === 'file') {
+      handleHistoryFileDownload(req, res, decodeURIComponent(segments[1]));
+      return;
+    }
   }
 
   if (req.method === 'GET' && parsedUrl.pathname === '/downloads') {


### PR DESCRIPTION
## Summary
- Track download file paths in the database and capture them from the download manager so history items know where the final assets live
- Extend the server with history endpoints to start downloads, serve completed files through the browser, and delete records while also removing files from disk
- Refresh the history page UI with mobile-friendly styling, action icons, and an add-download dialog that validates URLs before scheduling new work

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d65657b11c83268690ec04b44e599f