### PR TITLE
Refactor history page client to React

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node dist/build/copy-history-assets.js",
     "start": "node dist/index.js",
     "dev": "ts-node --transpile-only src/index.ts"
   },

--- a/server/src/build/copy-history-assets.ts
+++ b/server/src/build/copy-history-assets.ts
@@ -1,0 +1,17 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function copyAsset(relativeSource: string, relativeDestination: string): void {
+    const distDir = path.resolve(__dirname, '..');
+    const sourcePath = path.resolve(distDir, '../src', relativeSource);
+    const destinationPath = path.resolve(distDir, relativeDestination);
+
+    if (!fs.existsSync(sourcePath)) {
+        throw new Error(`Missing history asset at ${sourcePath}`);
+    }
+
+    fs.copyFileSync(sourcePath, destinationPath);
+}
+
+copyAsset('history-client.js', 'history-client.js');
+copyAsset('history-page.css', 'history-page.css');

--- a/server/src/history-client.js
+++ b/server/src/history-client.js
@@ -1,0 +1,1058 @@
+(function () {
+  function ready(callback) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", callback, { once: true });
+    } else {
+      callback();
+    }
+  }
+
+  function parseProps() {
+    const propsElement = document.getElementById("history-props");
+    if (!propsElement) {
+      return null;
+    }
+    try {
+      const raw = propsElement.textContent || "{}";
+      return JSON.parse(raw);
+    } catch (error) {
+      console.error("Failed to parse history props", error);
+      return null;
+    }
+  }
+
+  function formatProgress(value) {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return 0;
+    }
+    if (numeric <= 0) {
+      return 0;
+    }
+    if (numeric >= 100) {
+      return 100;
+    }
+    return Math.round(numeric);
+  }
+
+  function getProgressFromItem(item) {
+    if (item && Number.isFinite(item.percent)) {
+      return formatProgress(item.percent);
+    }
+    return item && item.status === "completed" ? 100 : 0;
+  }
+
+  function validateUrl(value) {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function deriveUrlId(value) {
+    try {
+      const parsed = new URL(value);
+      if (parsed.searchParams.has("list")) {
+        return parsed.searchParams.get("list") || "";
+      }
+      const pathname = parsed.pathname || "";
+      const shortsMatch = pathname.match(/\/shorts\/([a-zA-Z0-9_-]{11})/u);
+      if (shortsMatch && shortsMatch[1]) {
+        return shortsMatch[1];
+      }
+      const watchId = parsed.searchParams.get("v");
+      if (watchId) {
+        return watchId;
+      }
+      if (parsed.hostname === "youtu.be") {
+        const parts = pathname.split("/");
+        if (parts.length > 1 && parts[1]) {
+          return parts[1];
+        }
+      }
+      return parsed.href;
+    } catch (_error) {
+      return "";
+    }
+  }
+
+  function extractFilename(response, fallback) {
+    const disposition = response.headers.get("Content-Disposition");
+    if (!disposition) {
+      return fallback;
+    }
+    const encodedMatch = /filename\*=UTF-8''([^;]+)/iu.exec(disposition);
+    const quotedMatch = /filename="?([^";]+)"?/iu.exec(disposition);
+    const raw = (encodedMatch && encodedMatch[1]) || (quotedMatch && quotedMatch[1]);
+    if (!raw) {
+      return fallback;
+    }
+    try {
+      return decodeURIComponent(raw.trim());
+    } catch (_error) {
+      return raw.trim();
+    }
+  }
+
+  function buildPageLink(baseParams, overrides) {
+    const params = new URLSearchParams(baseParams);
+    Object.keys(overrides || {}).forEach(function (key) {
+      const value = overrides[key];
+      if (value === null || value === undefined) {
+        params.delete(key);
+      } else {
+        params.set(key, String(value));
+      }
+    });
+    const queryString = params.toString();
+    return queryString ? "?" + queryString : "";
+  }
+
+  ready(function () {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!window.React || !window.ReactDOM) {
+      console.error("React and ReactDOM must be loaded before history client initialises.");
+      return;
+    }
+
+    const initialProps = parseProps();
+    if (!initialProps) {
+      return;
+    }
+
+    const ReactGlobal = window.React;
+    const ReactDOMGlobal = window.ReactDOM;
+    const h = ReactGlobal.createElement;
+    const Fragment = ReactGlobal.Fragment;
+    const useCallback = ReactGlobal.useCallback;
+    const useEffect = ReactGlobal.useEffect;
+    const useMemo = ReactGlobal.useMemo;
+    const useState = ReactGlobal.useState;
+    const hydrateRoot = ReactDOMGlobal.hydrateRoot;
+
+    function ProgressCell(props) {
+      return h(
+        "div",
+        { className: "progress-wrapper", role: "progressbar", "aria-valuenow": props.progress, "aria-valuemin": 0, "aria-valuemax": 100 },
+        h(
+          "div",
+          { className: "progress-track" },
+          h("div", { className: "progress-fill", style: { width: props.progress + "%" } })
+        ),
+        h("span", { className: "progress-value" }, props.progress + "%")
+      );
+    }
+
+    function ActionsCell(props) {
+      const status = props.item.status || "";
+      const isActive = status === "downloading" || status === "queued";
+      const fileExists = Boolean(props.item.filePath);
+      const downloadBusy = Boolean(props.isDownloadPending);
+      const stopBusy = Boolean(props.isStopPending);
+      const resumeBusy = Boolean(props.isResumePending);
+      const removeBusy = Boolean(props.isRemovePending);
+      const deleteBusy = Boolean(props.isDeletePending);
+      const canDownload = !props.downloadDisabled && !downloadBusy;
+
+      return h(
+        Fragment,
+        null,
+        h(
+          "button",
+          {
+            className: "icon-button stop-button",
+            "data-url-id": props.urlId,
+            title: "다운로드 정지",
+            "aria-label": "다운로드 정지",
+            disabled: !isActive || stopBusy,
+            onClick: props.onStop
+              ? function (event) {
+                  event.preventDefault();
+                  props.onStop(props.urlId);
+                }
+              : undefined
+          },
+          h(
+            "svg",
+            { viewBox: "0 0 24 24", "aria-hidden": "true" },
+            h("path", { d: "M8 5h3v14H8zm5 0h3v14h-3z" })
+          )
+        ),
+        h(
+          "button",
+          {
+            className: "icon-button resume-button",
+            "data-url-id": props.urlId,
+            title: "다운로드 재시작",
+            "aria-label": "다운로드 재시작",
+            disabled: isActive || resumeBusy,
+            onClick: props.onResume
+              ? function (event) {
+                  event.preventDefault();
+                  props.onResume(props.urlId);
+                }
+              : undefined
+          },
+          h(
+            "svg",
+            { viewBox: "0 0 24 24", "aria-hidden": "true" },
+            h("path", { d: "M8 5v14l11-7z" })
+          )
+        ),
+        h(
+          "button",
+          {
+            className: "icon-button download-button",
+            "data-url-id": props.urlId,
+            title: props.downloadTitle,
+            "aria-label": props.downloadTitle,
+            disabled: !canDownload,
+            "data-loading": downloadBusy ? "true" : undefined,
+            "aria-busy": downloadBusy ? "true" : undefined,
+            onClick: props.onDownload
+              ? function (event) {
+                  event.preventDefault();
+                  props.onDownload(props.urlId);
+                }
+              : undefined
+          },
+          h("span", { className: "spinner", "aria-hidden": "true" }),
+          h(
+            "svg",
+            { viewBox: "0 0 24 24", "aria-hidden": "true" },
+            h("path", { d: "M5 20h14v-2H5v2zm7-18l-5.5 6h3.5v6h4v-6H17L12 2z" })
+          )
+        ),
+        h(
+          "button",
+          {
+            className: "icon-button remove-file-button",
+            "data-url-id": props.urlId,
+            title: fileExists ? "파일만 삭제" : "삭제할 파일이 없습니다.",
+            "aria-label": "파일 삭제",
+            disabled: !fileExists || removeBusy,
+            onClick: props.onRemoveFile
+              ? function (event) {
+                  event.preventDefault();
+                  props.onRemoveFile(props.urlId);
+                }
+              : undefined
+          },
+          h(
+            "svg",
+            { viewBox: "0 0 24 24", "aria-hidden": "true" },
+            h("path", { d: "M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" }),
+            h("path", { d: "M10 11h1.5v6H10zm2.5 0H14v6h-1.5z" })
+          )
+        ),
+        h(
+          "button",
+          {
+            className: "icon-button delete-button",
+            "data-url-id": props.urlId,
+            title: "이력 삭제",
+            "aria-label": "이력 삭제",
+            disabled: deleteBusy,
+            onClick: props.onDelete
+              ? function (event) {
+                  event.preventDefault();
+                  props.onDelete(props.urlId);
+                }
+              : undefined
+          },
+          h(
+            "svg",
+            { viewBox: "0 0 24 24", "aria-hidden": "true" },
+            h("path", { d: "M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" })
+          )
+        )
+      );
+    }
+
+    function TableRow(props) {
+      const item = props.item;
+      const downloadPending = props.downloadPending || {};
+      const stopPending = props.stopPending || {};
+      const resumePending = props.resumePending || {};
+      const removePending = props.removePending || {};
+      const deletePending = props.deletePending || {};
+      const title = (item.title && item.title.trim()) || "";
+      const urlId = item.urlId || "";
+      const status = item.status || "unknown";
+      const lastError = item.lastError || "";
+      const createdAt = item.createdAt || "-";
+      const updatedAt = item.updatedAt || "-";
+      const sourceUrl = item.url || "";
+      const urlDisplay = sourceUrl || urlId || "";
+      const statusClass = "status-badge status-" + status;
+      const progressValue = getProgressFromItem(item);
+      const fileAvailable = Boolean(item.filePath);
+      const downloadDisabled = !fileAvailable || status !== "completed";
+      const downloadTitle = downloadDisabled ? "완료된 항목만 다운로드할 수 있습니다." : "파일 다운로드";
+
+      return h(
+        "tr",
+        { "data-url-id": urlId, "data-status": status, "data-source-url": sourceUrl, "data-file-path": item.filePath || "" },
+        h(
+          "td",
+          { className: "title", "data-label": "제목" },
+          h("div", { className: "title-text", title: title || "(제목 없음)" }, title ? title : h("span", { className: "muted" }, "(제목 없음)")),
+          h(
+            "div",
+            { className: "title-url", title: urlDisplay || "-" },
+            sourceUrl
+              ? h("a", { href: sourceUrl, target: "_blank", rel: "noopener noreferrer" }, urlDisplay)
+              : urlDisplay
+              ? urlDisplay
+              : h("span", { className: "muted" }, "-")
+          )
+        ),
+        h(
+          "td",
+          { className: "status", "data-label": "상태" },
+          h("span", { className: statusClass }, status)
+        ),
+        h(
+          "td",
+          { className: "progress", "data-label": "진행률" },
+          h(ProgressCell, { progress: progressValue })
+        ),
+        h(
+          "td",
+          { className: "error", "data-label": "오류" },
+          lastError ? h("span", { title: lastError }, lastError) : h("span", { className: "muted" }, "-")
+        ),
+        h("td", { className: "created", "data-label": "생성일" }, createdAt),
+        h("td", { className: "updated", "data-label": "업데이트" }, updatedAt),
+        h(
+          "td",
+          { className: "actions", "data-label": "작업" },
+          h(ActionsCell, {
+            item: item,
+            urlId: urlId,
+            downloadTitle: downloadTitle,
+            downloadDisabled: downloadDisabled,
+            onStop: props.onStop,
+            onResume: props.onResume,
+            onDownload: props.onDownload,
+            onRemoveFile: props.onRemoveFile,
+            onDelete: props.onDelete,
+            isDownloadPending: downloadPending[urlId],
+            isStopPending: stopPending[urlId],
+            isResumePending: resumePending[urlId],
+            isRemovePending: removePending[urlId],
+            isDeletePending: deletePending[urlId]
+          })
+        )
+      );
+    }
+
+    function HistoryTable(props) {
+      const rows = props.items || [];
+      const header = h(
+        "thead",
+        null,
+        h(
+          "tr",
+          null,
+          h("th", null, "제목"),
+          h("th", null, "상태"),
+          h("th", null, "진행률"),
+          h("th", null, "오류"),
+          h("th", null, "생성일"),
+          h("th", null, "업데이트"),
+          h("th", { className: "actions-column" }, "작업")
+        )
+      );
+
+      if (rows.length === 0) {
+        return h(
+          "table",
+          { role: "grid" },
+          header,
+          h(
+            "tbody",
+            null,
+            h(
+              "tr",
+              { className: "empty-row" },
+              h("td", { colSpan: 7 }, "검색 결과가 없습니다.")
+            )
+          )
+        );
+      }
+
+      return h(
+        "table",
+        { role: "grid" },
+        header,
+        h(
+          "tbody",
+          null,
+          rows.map(function (item, index) {
+            const key = item.urlId || "row-" + index;
+            return h(TableRow, {
+              key: key,
+              item: item,
+              onStop: props.onStop,
+              onResume: props.onResume,
+              onDownload: props.onDownload,
+              onRemoveFile: props.onRemoveFile,
+              onDelete: props.onDelete,
+              downloadPending: props.downloadPending,
+              stopPending: props.stopPending,
+              resumePending: props.resumePending,
+              removePending: props.removePending,
+              deletePending: props.deletePending
+            });
+          })
+        )
+      );
+    }
+
+    function Pagination(props) {
+      const baseParams = new URLSearchParams();
+      if (props.searchTerm) {
+        baseParams.set("search", props.searchTerm);
+      }
+      baseParams.set("pageSize", String(props.pageSize));
+
+      const prevLink = props.page > 1 ? buildPageLink(baseParams, { page: props.page - 1 }) : null;
+      const nextLink = props.page < props.totalPages ? buildPageLink(baseParams, { page: props.page + 1 }) : null;
+
+      return h(
+        "div",
+        { className: "pagination" },
+        prevLink ? h("a", { href: prevLink, "aria-label": "이전 페이지" }, "이전") : h("span", { className: "disabled" }, "이전"),
+        h("span", { className: "current" }, props.page + " / " + props.totalPages),
+        nextLink ? h("a", { href: nextLink, "aria-label": "다음 페이지" }, "다음") : h("span", { className: "disabled" }, "다음")
+      );
+    }
+
+    function SearchForm(props) {
+      return h(
+        "form",
+        { method: "GET", action: "/history", className: "search-form" },
+        h("label", { htmlFor: "search", className: "visually-hidden" }, "URL ID 또는 제목 검색"),
+        h("input", {
+          type: "text",
+          id: "search",
+          name: "search",
+          placeholder: "URL ID 또는 제목 검색",
+          defaultValue: props.searchTerm || "",
+          "aria-label": "URL ID 또는 제목 검색"
+        }),
+        h("button", { type: "submit", className: "primary" }, "검색")
+      );
+    }
+
+    function AddDownloadDialog(props) {
+      return h(
+        "div",
+        {
+          className: "dialog-backdrop" + (props.open ? " visible" : ""),
+          "data-dialog": "add-download",
+          hidden: !props.open,
+          onClick: function (event) {
+            if (event.target === event.currentTarget && props.onClose) {
+              props.onClose();
+            }
+          }
+        },
+        h(
+          "div",
+          { className: "dialog", role: "dialog", "aria-modal": "true", "aria-labelledby": "add-download-title" },
+          h("h2", { id: "add-download-title" }, "다운로드 추가"),
+          h("p", null, "다운로드할 영상의 URL을 입력하세요."),
+          h(
+            "form",
+            {
+              "data-form": "add-download",
+              onSubmit: function (event) {
+                event.preventDefault();
+                if (props.onSubmit) {
+                  props.onSubmit();
+                }
+              }
+            },
+            h("label", { htmlFor: "download-url", className: "visually-hidden" }, "다운로드 URL"),
+            h("input", {
+              type: "url",
+              id: "download-url",
+              name: "url",
+              placeholder: "https://",
+              required: true,
+              value: props.urlValue,
+              onChange: function (event) {
+                if (props.onUrlChange) {
+                  props.onUrlChange(event.target.value);
+                }
+              }
+            }),
+            h("p", { className: "form-helper", "data-error-message": true, hidden: !props.errorMessage }, props.errorMessage || "유효한 URL을 입력해주세요."),
+            h(
+              "div",
+              { className: "dialog-buttons" },
+              h(
+                "button",
+                {
+                  type: "button",
+                  className: "secondary",
+                  "data-action": "cancel-dialog",
+                  onClick: function (event) {
+                    event.preventDefault();
+                    if (props.onClose) {
+                      props.onClose();
+                    }
+                  }
+                },
+                "취소"
+              ),
+              h("button", { type: "submit", className: "primary", disabled: props.isSubmitting }, props.isSubmitting ? "요청 중..." : "다운로드 요청")
+            )
+          )
+        )
+      );
+    }
+
+    function HistoryApp(props) {
+      const [items, setItems] = useState(function () {
+        return (props.items || []).map(function (item) {
+          return Object.assign({}, item);
+        });
+      });
+      const [dialogOpen, setDialogOpen] = useState(false);
+      const [urlValue, setUrlValue] = useState("");
+      const [formError, setFormError] = useState("");
+      const [isSubmitting, setIsSubmitting] = useState(false);
+      const [downloadPending, setDownloadPending] = useState({});
+      const [stopPending, setStopPending] = useState({});
+      const [resumePending, setResumePending] = useState({});
+      const [removePending, setRemovePending] = useState({});
+      const [deletePending, setDeletePending] = useState({});
+
+      const updateItemState = useCallback(function (state) {
+        if (!state || !state.urlId) {
+          return;
+        }
+        setItems(function (previous) {
+          let found = false;
+          const next = previous.map(function (entry) {
+            if (entry.urlId !== state.urlId) {
+              return entry;
+            }
+            found = true;
+            const updated = Object.assign({}, entry);
+            if (typeof state.title === "string") {
+              updated.title = state.title;
+            }
+            if (typeof state.url === "string") {
+              updated.url = state.url;
+            }
+            if (typeof state.status === "string") {
+              updated.status = state.status;
+            }
+            if (Object.prototype.hasOwnProperty.call(state, "filePath")) {
+              updated.filePath = typeof state.filePath === "string" ? state.filePath : null;
+            }
+            if (Object.prototype.hasOwnProperty.call(state, "error")) {
+              updated.lastError = state.error ? String(state.error) : "";
+            }
+            if (Object.prototype.hasOwnProperty.call(state, "lastError")) {
+              updated.lastError = state.lastError ? String(state.lastError) : "";
+            }
+            if (Object.prototype.hasOwnProperty.call(state, "percent")) {
+              const numeric = Number(state.percent);
+              updated.percent = Number.isFinite(numeric) ? numeric : 0;
+            }
+            return updated;
+          });
+          return found ? next : previous;
+        });
+      }, []);
+
+      const setBusy = useCallback(function (setter, urlId, value) {
+        setter(function (previous) {
+          const next = Object.assign({}, previous);
+          if (value) {
+            next[urlId] = true;
+          } else {
+            delete next[urlId];
+          }
+          return next;
+        });
+      }, []);
+
+      const removeFileAfterDownload = useCallback(function (urlId, background) {
+        return fetch("/history/" + encodeURIComponent(urlId) + "/file", { method: "DELETE" })
+          .then(function (response) {
+            if (!response.ok) {
+              if (response.status !== 404) {
+                return response
+                  .json()
+                  .catch(function () {
+                    return {};
+                  })
+                  .then(function (data) {
+                    if (!background) {
+                      window.alert((data && data.error) || "다운로드 후 파일 삭제에 실패했습니다.");
+                    }
+                  });
+              }
+              return null;
+            }
+            return response
+              .json()
+              .catch(function () {
+                return null;
+              })
+              .then(function (state) {
+                if (state) {
+                  updateItemState(state);
+                }
+                return state;
+              });
+          })
+          .catch(function () {
+            if (!background) {
+              window.alert("다운로드 후 파일 삭제 중 오류가 발생했습니다.");
+            }
+          });
+      }, [updateItemState]);
+
+      const handleDownload = useCallback(function (urlId) {
+        if (!urlId || downloadPending[urlId]) {
+          return;
+        }
+        setBusy(setDownloadPending, urlId, true);
+        fetch("/history/" + encodeURIComponent(urlId) + "/file", { method: "GET" })
+          .then(function (response) {
+            if (!response.ok) {
+              return response
+                .json()
+                .catch(function () {
+                  return {};
+                })
+                .then(function (data) {
+                  window.alert((data && data.error) || "파일을 다운로드할 수 없습니다.");
+                });
+            }
+            return response.blob().then(function (blob) {
+              const filename = extractFilename(response, urlId + ".bin");
+              const objectUrl = URL.createObjectURL(blob);
+              let revoked = false;
+              const revoke = function () {
+                if (revoked) {
+                  return;
+                }
+                revoked = true;
+                try {
+                  URL.revokeObjectURL(objectUrl);
+                } catch (_error) {
+                  // ignore
+                }
+              };
+              const revokeTimeout = window.setTimeout(revoke, 120000);
+              window.addEventListener(
+                "pagehide",
+                function () {
+                  window.clearTimeout(revokeTimeout);
+                  revoke();
+                },
+                { once: true }
+              );
+
+              const isIos =
+                /iP(ad|hone|od)/i.test(window.navigator.userAgent) ||
+                (window.navigator.platform === "MacIntel" && window.navigator.maxTouchPoints > 1);
+              const supportsDownloadAttribute = "download" in HTMLAnchorElement.prototype && !isIos;
+              let navigatedAway = false;
+
+              if (supportsDownloadAttribute) {
+                const anchor = document.createElement("a");
+                anchor.href = objectUrl;
+                anchor.download = filename;
+                anchor.rel = "noopener";
+                document.body.appendChild(anchor);
+                anchor.click();
+                anchor.remove();
+              } else {
+                const openedWindow = window.open(objectUrl, "_blank", "noopener");
+                if (!openedWindow) {
+                  navigatedAway = true;
+                  window.location.href = objectUrl;
+                }
+              }
+
+              if (navigatedAway) {
+                removeFileAfterDownload(urlId, true);
+              } else {
+                return removeFileAfterDownload(urlId, false);
+              }
+              return null;
+            });
+          })
+          .catch(function () {
+            window.alert("파일 다운로드 중 오류가 발생했습니다.");
+          })
+          .finally(function () {
+            setBusy(setDownloadPending, urlId, false);
+          });
+      }, [downloadPending, removeFileAfterDownload, setBusy, setDownloadPending]);
+
+      const handleRemoveFile = useCallback(function (urlId) {
+        if (!urlId || removePending[urlId]) {
+          return;
+        }
+        const confirmed = window.confirm("이력은 유지하고 서버에 저장된 파일만 삭제합니다. 계속하시겠습니까?");
+        if (!confirmed) {
+          return;
+        }
+        setBusy(setRemovePending, urlId, true);
+        fetch("/history/" + encodeURIComponent(urlId) + "/file", { method: "DELETE" })
+          .then(function (response) {
+            return response
+              .json()
+              .catch(function () {
+                return null;
+              })
+              .then(function (state) {
+                if (!response.ok) {
+                  window.alert((state && state.error) || "파일 삭제에 실패했습니다.");
+                  return;
+                }
+                if (state) {
+                  updateItemState(state);
+                }
+              });
+          })
+          .catch(function () {
+            window.alert("파일 삭제 중 오류가 발생했습니다.");
+          })
+          .finally(function () {
+            setBusy(setRemovePending, urlId, false);
+          });
+      }, [removePending, setBusy, setRemovePending, updateItemState]);
+
+      const handleDelete = useCallback(function (urlId) {
+        if (!urlId || deletePending[urlId]) {
+          return;
+        }
+        const confirmed = window.confirm("정말로 이 다운로드 이력을 삭제하시겠습니까? 파일도 함께 삭제됩니다.");
+        if (!confirmed) {
+          return;
+        }
+        setBusy(setDeletePending, urlId, true);
+        fetch("/history/" + encodeURIComponent(urlId), { method: "DELETE" })
+          .then(function (response) {
+            return response
+              .json()
+              .catch(function () {
+                return null;
+              })
+              .then(function (data) {
+                if (!response.ok) {
+                  window.alert((data && data.error) || "삭제에 실패했습니다.");
+                  return;
+                }
+                window.location.reload();
+              });
+          })
+          .catch(function () {
+            window.alert("삭제 중 오류가 발생했습니다.");
+          })
+          .finally(function () {
+            setBusy(setDeletePending, urlId, false);
+          });
+      }, [deletePending, setBusy, setDeletePending]);
+
+      const handleStop = useCallback(function (urlId) {
+        if (!urlId || stopPending[urlId]) {
+          return;
+        }
+        setBusy(setStopPending, urlId, true);
+        fetch("/stop_download", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ urlId: urlId })
+        })
+          .then(function (response) {
+            return response
+              .json()
+              .catch(function () {
+                return null;
+              })
+              .then(function (state) {
+                if (!response.ok) {
+                  window.alert((state && state.error) || "다운로드 정지에 실패했습니다.");
+                  return;
+                }
+                if (state) {
+                  updateItemState(state);
+                }
+              });
+          })
+          .catch(function () {
+            window.alert("다운로드 정지 중 오류가 발생했습니다.");
+          })
+          .finally(function () {
+            setBusy(setStopPending, urlId, false);
+          });
+      }, [stopPending, setBusy, setStopPending, updateItemState]);
+
+      const handleResume = useCallback(function (urlId) {
+        if (!urlId || resumePending[urlId]) {
+          return;
+        }
+        setBusy(setResumePending, urlId, true);
+        fetch("/restart_download", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ urlId: urlId })
+        })
+          .then(function (response) {
+            return response
+              .json()
+              .catch(function () {
+                return null;
+              })
+              .then(function (state) {
+                if (!response.ok) {
+                  window.alert((state && state.error) || "다운로드 재시작에 실패했습니다.");
+                  return;
+                }
+                if (state) {
+                  updateItemState(state);
+                }
+              });
+          })
+          .catch(function () {
+            window.alert("다운로드 재시작 중 오류가 발생했습니다.");
+          })
+          .finally(function () {
+            setBusy(setResumePending, urlId, false);
+          });
+      }, [resumePending, setBusy, setResumePending, updateItemState]);
+
+      const handleOpenDialog = useCallback(function () {
+        setDialogOpen(true);
+        setFormError("");
+        setUrlValue("");
+      }, []);
+
+      const handleCloseDialog = useCallback(function () {
+        setDialogOpen(false);
+        setFormError("");
+        setUrlValue("");
+      }, []);
+
+      const handleDialogSubmit = useCallback(function () {
+        const trimmed = urlValue.trim();
+        if (!validateUrl(trimmed)) {
+          setFormError("유효한 URL을 입력해주세요.");
+          return;
+        }
+        setFormError("");
+        setIsSubmitting(true);
+        fetch("/history/request-download", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ url: trimmed, urlId: deriveUrlId(trimmed) })
+        })
+          .then(function (response) {
+            return response
+              .json()
+              .catch(function () {
+                return {};
+              })
+              .then(function (data) {
+                if (!response.ok) {
+                  window.alert((data && data.error) || "다운로드 요청에 실패했습니다.");
+                  return;
+                }
+                handleCloseDialog();
+                window.location.reload();
+              });
+          })
+          .catch(function () {
+            window.alert("다운로드 요청 중 오류가 발생했습니다.");
+          })
+          .finally(function () {
+            setIsSubmitting(false);
+          });
+      }, [urlValue, handleCloseDialog]);
+
+      useEffect(function () {
+        let active = true;
+        let socket = null;
+        let reconnectTimer = null;
+
+        function connect() {
+          if (!active) {
+            return;
+          }
+          const wsPath = props.wsPath || "/";
+          const normalisedPath = wsPath.startsWith("/") ? wsPath : "/" + wsPath;
+          const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+          const url = protocol + "//" + window.location.host + normalisedPath;
+          try {
+            socket = new WebSocket(url);
+          } catch (error) {
+            console.error("웹소켓 연결 실패", error);
+            reconnectTimer = window.setTimeout(connect, 2000);
+            return;
+          }
+
+          socket.addEventListener("message", function (event) {
+            try {
+              const data = JSON.parse(String(event.data));
+              if (data && data.type === "download" && data.payload) {
+                updateItemState(data.payload);
+              } else if (data && data.type === "download-finished" && data.payload) {
+                const payload = Object.assign({}, data.payload, { percent: 100 });
+                updateItemState(payload);
+              }
+            } catch (err) {
+              console.error("웹소켓 메시지 파싱 실패", err);
+            }
+          });
+
+          socket.addEventListener("close", function () {
+            if (!active) {
+              return;
+            }
+            reconnectTimer = window.setTimeout(connect, 2000);
+          });
+
+          socket.addEventListener("error", function () {
+            if (socket) {
+              socket.close();
+            }
+          });
+        }
+
+        connect();
+
+        return function () {
+          active = false;
+          if (socket) {
+            socket.close();
+          }
+          if (reconnectTimer) {
+            window.clearTimeout(reconnectTimer);
+          }
+        };
+      }, [props.wsPath, updateItemState]);
+
+      const summary = useMemo(function () {
+        return {
+          total: props.total,
+          showingFrom: props.showingFrom,
+          showingTo: props.showingTo,
+          page: props.page,
+          pageSize: props.pageSize,
+          totalPages: props.totalPages,
+          searchTerm: props.searchTerm || ""
+        };
+      }, [props.total, props.showingFrom, props.showingTo, props.page, props.pageSize, props.totalPages, props.searchTerm]);
+
+      return h(
+        Fragment,
+        null,
+        h(
+          "div",
+          { className: "card" },
+          h("h1", null, "다운로드 이력"),
+          h(
+            "div",
+            { className: "toolbar" },
+            h(SearchForm, { searchTerm: summary.searchTerm }),
+            h(
+              "div",
+              { className: "toolbar-actions" },
+              h(
+                "button",
+                {
+                  type: "button",
+                  className: "secondary",
+                  onClick: function () {
+                    window.location.reload();
+                  }
+                },
+                "새로고침"
+              ),
+              h(
+                "button",
+                { type: "button", className: "primary", onClick: handleOpenDialog },
+                "다운로드 추가"
+              )
+            )
+          ),
+          h(HistoryTable, {
+            items: items,
+            onStop: handleStop,
+            onResume: handleResume,
+            onDownload: handleDownload,
+            onRemoveFile: handleRemoveFile,
+            onDelete: handleDelete,
+            downloadPending: downloadPending,
+            stopPending: stopPending,
+            resumePending: resumePending,
+            removePending: removePending,
+            deletePending: deletePending
+          }),
+          h(
+            "div",
+            { className: "summary" },
+            h(
+              "span",
+              null,
+              "총 " +
+                summary.total.toLocaleString() +
+                "건 중 " +
+                summary.showingFrom.toLocaleString() +
+                "-" +
+                summary.showingTo.toLocaleString() +
+                " 표시"
+            ),
+            h(Pagination, {
+              page: summary.page,
+              totalPages: summary.totalPages,
+              pageSize: summary.pageSize,
+              searchTerm: summary.searchTerm
+            })
+          )
+        ),
+        h(AddDownloadDialog, {
+          open: dialogOpen,
+          onClose: handleCloseDialog,
+          onSubmit: handleDialogSubmit,
+          urlValue: urlValue,
+          onUrlChange: function (value) {
+            setUrlValue(value);
+            if (formError) {
+              setFormError("");
+            }
+          },
+          errorMessage: formError,
+          isSubmitting: isSubmitting
+        })
+      );
+    }
+
+    const rootElement = document.getElementById("history-root");
+    if (!rootElement) {
+      return;
+    }
+
+    hydrateRoot(rootElement, h(HistoryApp, initialProps));
+  });
+})();

--- a/server/src/history-page-assets.ts
+++ b/server/src/history-page-assets.ts
@@ -1,7 +1,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { createRequire } from 'node:module';
 
 let cachedHistoryCss: string | null = null;
+let cachedReactScript: string | null = null;
+let cachedReactDomScript: string | null = null;
+let cachedHistoryClientScript: string | null = null;
+
+const requireModule = createRequire(__filename);
 
 function resolveCssPath(): string {
     const candidates = [
@@ -27,4 +33,51 @@ export function getHistoryPageCss(): string {
     const cssPath = resolveCssPath();
     cachedHistoryCss = fs.readFileSync(cssPath, 'utf8');
     return cachedHistoryCss;
+}
+
+function resolveHistoryClientScriptPath(): string {
+    const candidates = [
+        path.resolve(__dirname, 'history-client.js'),
+        path.resolve(__dirname, '../src/history-client.js'),
+        path.resolve(process.cwd(), 'src/history-client.js')
+    ];
+
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+    }
+
+    throw new Error('history-client.js not found');
+}
+
+function readUmdScript(moduleName: string, fileName: string): string {
+    const packageJsonPath = requireModule.resolve(`${moduleName}/package.json`);
+    const moduleDir = path.dirname(packageJsonPath);
+    const scriptPath = path.join(moduleDir, 'umd', fileName);
+    return fs.readFileSync(scriptPath, 'utf8');
+}
+
+export function getReactUmdScript(): string {
+    if (!cachedReactScript) {
+        cachedReactScript = readUmdScript('react', 'react.production.min.js');
+    }
+    return cachedReactScript;
+}
+
+export function getReactDomUmdScript(): string {
+    if (!cachedReactDomScript) {
+        cachedReactDomScript = readUmdScript('react-dom', 'react-dom.production.min.js');
+    }
+    return cachedReactDomScript;
+}
+
+export function getHistoryClientScript(): string {
+    if (cachedHistoryClientScript) {
+        return cachedHistoryClientScript;
+    }
+
+    const scriptPath = resolveHistoryClientScriptPath();
+    cachedHistoryClientScript = fs.readFileSync(scriptPath, 'utf8');
+    return cachedHistoryClientScript;
 }

--- a/server/src/history-page-view.tsx
+++ b/server/src/history-page-view.tsx
@@ -2,503 +2,6 @@ import React from 'react';
 import { URLSearchParams } from 'node:url';
 import type { DownloadRecordRow } from './database';
 
-interface HistoryClientConfig {
-  wsPath: string;
-}
-
-function historyClient(config: HistoryClientConfig): void {
-  const backdrop = document.querySelector('[data-dialog="add-download"]') as HTMLElement | null;
-  const form = backdrop ? (backdrop.querySelector('form[data-form="add-download"]') as HTMLFormElement | null) : null;
-  const urlInput = form ? (form.querySelector('input[name="url"]') as HTMLInputElement | null) : null;
-  const errorMessage = form ? (form.querySelector('[data-error-message]') as HTMLElement | null) : null;
-
-  function openDialog(): void {
-    if (!backdrop) return;
-    backdrop.hidden = false;
-    requestAnimationFrame(() => {
-      backdrop.classList.add('visible');
-      if (urlInput) {
-        urlInput.value = '';
-        urlInput.focus();
-      }
-      if (errorMessage) {
-        errorMessage.hidden = true;
-      }
-    });
-  }
-
-  function closeDialog(): void {
-    if (!backdrop) return;
-    backdrop.classList.remove('visible');
-    window.setTimeout(() => {
-      backdrop.hidden = true;
-    }, 150);
-  }
-
-  function validateUrl(value: string): boolean {
-    try {
-      const parsed = new URL(value);
-      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-    } catch (_error) {
-      return false;
-    }
-  }
-
-  function deriveUrlId(value: string): string {
-    try {
-      const parsed = new URL(value);
-      if (parsed.searchParams.has('list')) {
-        return parsed.searchParams.get('list') ?? '';
-      }
-      const pathname = parsed.pathname || '';
-      const shortsMatch = pathname.match(/\/shorts\/([a-zA-Z0-9_-]{11})/u);
-      if (shortsMatch && shortsMatch[1]) {
-        return shortsMatch[1];
-      }
-      const watchId = parsed.searchParams.get('v');
-      if (watchId) {
-        return watchId;
-      }
-      if (parsed.hostname === 'youtu.be') {
-        const [, id] = pathname.split('/');
-        if (id) {
-          return id;
-        }
-      }
-      return parsed.href;
-    } catch (_error) {
-      return '';
-    }
-  }
-
-  const openButton = document.querySelector('[data-action="open-add-dialog"]');
-  openButton?.addEventListener('click', openDialog);
-
-  const refreshButton = document.querySelector('[data-action="refresh"]');
-  refreshButton?.addEventListener('click', () => {
-    window.location.reload();
-  });
-
-  backdrop?.addEventListener('click', (event) => {
-    if (event.target === backdrop) {
-      closeDialog();
-    }
-  });
-
-  const cancelButton = backdrop ? backdrop.querySelector('[data-action="cancel-dialog"]') : null;
-  cancelButton?.addEventListener('click', closeDialog);
-
-  form?.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    if (!urlInput) return;
-    const value = urlInput.value.trim();
-    if (!validateUrl(value)) {
-      if (errorMessage) {
-        errorMessage.hidden = false;
-      }
-      urlInput.focus();
-      return;
-    }
-
-    if (errorMessage) {
-      errorMessage.hidden = true;
-    }
-
-    try {
-      const response = await fetch('/history/request-download', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: value, urlId: deriveUrlId(value) })
-      });
-
-      if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
-        window.alert(data.error || '다운로드 요청에 실패했습니다.');
-        return;
-      }
-
-      closeDialog();
-      window.location.reload();
-    } catch (_error) {
-      window.alert('다운로드 요청 중 오류가 발생했습니다.');
-    }
-  });
-
-  const escapeSelector: (value: string) => string = typeof window.CSS !== 'undefined' && typeof window.CSS.escape === 'function'
-    ? (value: string) => window.CSS.escape(value)
-    : (value: string) => String(value).replace(/[\s#:;.]/g, '_');
-
-  function updateRowState(row: Element | null, state: Record<string, unknown>): void {
-    if (!row || !state) {
-      return;
-    }
-
-    if (typeof state.title === 'string' && state.title.trim()) {
-      const titleElement = row.querySelector('.title-text') as HTMLElement | null;
-      if (titleElement) {
-        const trimmed = state.title.trim();
-        titleElement.textContent = trimmed;
-        titleElement.title = trimmed;
-      }
-    }
-
-    if (typeof state.url === 'string' && state.url) {
-      (row as HTMLElement).dataset.sourceUrl = state.url;
-      const urlContainer = row.querySelector('.title-url') as HTMLElement | null;
-      if (urlContainer) {
-        const safeUrl = state.url;
-        urlContainer.innerHTML = `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>`;
-        urlContainer.title = safeUrl;
-      }
-    }
-
-    if (typeof state.status === 'string') {
-      (row as HTMLElement).dataset.status = state.status;
-      const badge = row.querySelector('.status .status-badge') as HTMLElement | null;
-      if (badge) {
-        const nextStatus = state.status.toLowerCase();
-        badge.textContent = nextStatus;
-        badge.className = `status-badge status-${nextStatus}`;
-      }
-    }
-
-    if (Object.prototype.hasOwnProperty.call(state, 'filePath')) {
-      const filePathValue = typeof state.filePath === 'string' ? state.filePath : '';
-      (row as HTMLElement).dataset.filePath = filePathValue;
-    }
-
-    if (Object.prototype.hasOwnProperty.call(state, 'error')) {
-      const errorCell = row.querySelector('.error') as HTMLElement | null;
-      if (errorCell) {
-        const message = state.error ? String(state.error) : '';
-        errorCell.innerHTML = message
-          ? `<span title="${message}">${message}</span>`
-          : '<span class="muted">-</span>';
-      }
-    }
-
-    if (Object.prototype.hasOwnProperty.call(state, 'percent')) {
-      const wrapper = row.querySelector('.progress .progress-wrapper') as HTMLElement | null;
-      const fill = row.querySelector('.progress .progress-fill') as HTMLElement | null;
-      const valueLabel = row.querySelector('.progress .progress-value') as HTMLElement | null;
-      if (wrapper && fill && valueLabel) {
-        const numeric = Number.isFinite(state.percent as number)
-          ? Math.max(0, Math.min(100, Number(state.percent)))
-          : 0;
-        const rounded = Math.round(numeric);
-        fill.style.width = `${rounded}%`;
-        wrapper.setAttribute('aria-valuenow', String(rounded));
-        valueLabel.textContent = `${rounded}%`;
-      }
-    }
-
-    const stopButton = row.querySelector('.stop-button') as HTMLButtonElement | null;
-    const resumeButton = row.querySelector('.resume-button') as HTMLButtonElement | null;
-    const isActive = state.status === 'downloading' || state.status === 'queued';
-    if (stopButton) {
-      stopButton.disabled = !isActive;
-    }
-    if (resumeButton) {
-      resumeButton.disabled = isActive;
-    }
-
-    const downloadButton = row.querySelector('.download-button') as HTMLButtonElement | null;
-    const removeFileButton = row.querySelector('.remove-file-button') as HTMLButtonElement | null;
-    const currentStatus = typeof state.status === 'string'
-      ? state.status
-      : (row as HTMLElement).dataset.status || '';
-    const currentFilePath = Object.prototype.hasOwnProperty.call(state, 'filePath')
-      ? typeof state.filePath === 'string' ? state.filePath : ''
-      : (row as HTMLElement).dataset.filePath || '';
-    const hasFile = currentFilePath.trim().length > 0;
-    const canDownload = hasFile && currentStatus === 'completed';
-
-    if (downloadButton) {
-      downloadButton.disabled = !canDownload;
-      const title = canDownload ? '파일 다운로드' : '완료된 항목만 다운로드할 수 있습니다.';
-      downloadButton.title = title;
-      downloadButton.setAttribute('aria-label', title);
-    }
-
-    if (removeFileButton) {
-      removeFileButton.disabled = !hasFile;
-      removeFileButton.title = hasFile ? '파일만 삭제' : '삭제할 파일이 없습니다.';
-    }
-  }
-
-  function handleDownloadState(state: Record<string, unknown> & { urlId?: string }): void {
-    if (!state || !state.urlId) {
-      return;
-    }
-
-    const row = document.querySelector(`tr[data-url-id="${escapeSelector(state.urlId)}"]`);
-    if (!row) {
-      return;
-    }
-
-    updateRowState(row, state);
-  }
-
-  function openWebSocket(): WebSocket | null {
-    const normalisedPath = config.wsPath.startsWith('/') ? config.wsPath : `/${config.wsPath}`;
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${protocol}//${window.location.host}${normalisedPath}`;
-
-    let socket: WebSocket;
-    try {
-      socket = new WebSocket(wsUrl);
-    } catch (error) {
-      console.error('웹소켓 연결 실패', error);
-      return null;
-    }
-
-    socket.addEventListener('message', (event) => {
-      try {
-        const data = JSON.parse(String(event.data)) as { type?: string; payload?: Record<string, unknown> };
-        if (data?.type === 'download' && data.payload) {
-          handleDownloadState(data.payload);
-        } else if (data?.type === 'download-finished' && data.payload) {
-          handleDownloadState({ ...data.payload, percent: 100 });
-        }
-      } catch (messageError) {
-        console.error('웹소켓 메시지 파싱 실패', messageError);
-      }
-    });
-
-    socket.addEventListener('close', () => {
-      window.setTimeout(openWebSocket, 2000);
-    });
-
-    socket.addEventListener('error', () => {
-      socket.close();
-    });
-
-    return socket;
-  }
-
-  openWebSocket();
-
-  document.querySelectorAll<HTMLButtonElement>('.delete-button').forEach((button) => {
-    button.addEventListener('click', async () => {
-      const urlId = button.dataset.urlId;
-      if (!urlId) return;
-      const confirmed = window.confirm('정말로 이 다운로드 이력을 삭제하시겠습니까? 파일도 함께 삭제됩니다.');
-      if (!confirmed) {
-        return;
-      }
-
-      try {
-        const response = await fetch(`/history/${encodeURIComponent(urlId)}`, { method: 'DELETE' });
-        if (!response.ok) {
-          const data = (await response.json().catch(() => ({}))) as { error?: string };
-          window.alert(data.error || '삭제에 실패했습니다.');
-          return;
-        }
-        window.location.reload();
-      } catch (_error) {
-        window.alert('삭제 중 오류가 발생했습니다.');
-      }
-    });
-  });
-
-  document.querySelectorAll<HTMLButtonElement>('.stop-button').forEach((button) => {
-    button.addEventListener('click', async () => {
-      if (button.disabled) {
-        return;
-      }
-      const urlId = button.dataset.urlId;
-      if (!urlId) return;
-
-      button.disabled = true;
-      try {
-        const response = await fetch('/stop_download', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ urlId })
-        });
-
-        if (!response.ok) {
-          const data = (await response.json().catch(() => ({}))) as { error?: string };
-          window.alert(data.error || '다운로드 정지에 실패했습니다.');
-          button.disabled = false;
-          return;
-        }
-
-        const state = (await response.json().catch(() => null)) as Record<string, unknown> | null;
-        if (state) {
-          handleDownloadState(state);
-        }
-      } catch (_error) {
-        window.alert('다운로드 정지 중 오류가 발생했습니다.');
-        button.disabled = false;
-      }
-    });
-  });
-
-  document.querySelectorAll<HTMLButtonElement>('.resume-button').forEach((button) => {
-    button.addEventListener('click', async () => {
-      if (button.disabled) {
-        return;
-      }
-
-      const urlId = button.dataset.urlId;
-      if (!urlId) return;
-
-      button.disabled = true;
-      try {
-        const response = await fetch('/restart_download', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ urlId })
-        });
-
-        if (!response.ok) {
-          const data = (await response.json().catch(() => ({}))) as { error?: string };
-          window.alert(data.error || '다운로드 재시작에 실패했습니다.');
-          button.disabled = false;
-          return;
-        }
-
-        const state = (await response.json().catch(() => null)) as Record<string, unknown> | null;
-        if (state) {
-          handleDownloadState(state);
-        }
-      } catch (_error) {
-        window.alert('다운로드 재시작 중 오류가 발생했습니다.');
-        button.disabled = false;
-      }
-    });
-  });
-
-  function extractFilename(response: Response, fallback: string): string {
-    const disposition = response.headers.get('Content-Disposition');
-    if (!disposition) {
-      return fallback;
-    }
-
-    const encodedMatch = /filename\*=UTF-8''([^;]+)/iu.exec(disposition);
-    const quotedMatch = /filename="?([^";]+)"?/iu.exec(disposition);
-    const raw = encodedMatch?.[1] ?? quotedMatch?.[1];
-    if (!raw) {
-      return fallback;
-    }
-
-    try {
-      return decodeURIComponent(raw.trim());
-    } catch (_error) {
-      return raw.trim();
-    }
-  }
-
-  async function removeFileAfterDownload(urlId: string): Promise<void> {
-    try {
-      const response = await fetch(`/history/${encodeURIComponent(urlId)}/file`, { method: 'DELETE' });
-
-      if (!response.ok) {
-        if (response.status !== 404) {
-          const data = (await response.json().catch(() => ({}))) as { error?: string };
-          window.alert(data.error || '다운로드 후 파일 삭제에 실패했습니다.');
-        }
-        return;
-      }
-
-      const state = (await response.json().catch(() => null)) as Record<string, unknown> | null;
-      if (state) {
-        handleDownloadState(state);
-      }
-    } catch (_error) {
-      window.alert('다운로드 후 파일 삭제 중 오류가 발생했습니다.');
-    }
-  }
-
-  document.querySelectorAll<HTMLButtonElement>('.download-button').forEach((button) => {
-    button.addEventListener('click', async () => {
-      if (button.disabled) {
-        return;
-      }
-      const urlId = button.dataset.urlId;
-      if (!urlId) return;
-
-      button.disabled = true;
-      try {
-        const response = await fetch(`/history/${encodeURIComponent(urlId)}/file`, { method: 'GET' });
-        if (!response.ok) {
-          const data = (await response.json().catch(() => ({}))) as { error?: string };
-          window.alert(data.error || '파일을 다운로드할 수 없습니다.');
-          return;
-        }
-
-        const blob = await response.blob();
-        const filename = extractFilename(response, `${urlId}.bin`);
-        const objectUrl = URL.createObjectURL(blob);
-
-        const anchor = document.createElement('a');
-        anchor.href = objectUrl;
-        anchor.download = filename;
-        anchor.rel = 'noopener';
-        document.body.appendChild(anchor);
-        anchor.click();
-        anchor.remove();
-
-        window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
-        await removeFileAfterDownload(urlId);
-      } catch (_error) {
-        window.alert('파일 다운로드 중 오류가 발생했습니다.');
-      } finally {
-        button.disabled = false;
-      }
-    });
-  });
-
-  document.querySelectorAll<HTMLButtonElement>('.remove-file-button').forEach((button) => {
-    button.addEventListener('click', async () => {
-      if (button.disabled) {
-        return;
-      }
-      const urlId = button.dataset.urlId;
-      if (!urlId) return;
-
-      const confirmed = window.confirm('이력은 유지하고 서버에 저장된 파일만 삭제합니다. 계속하시겠습니까?');
-      if (!confirmed) {
-        return;
-      }
-
-      button.disabled = true;
-      try {
-        const response = await fetch(`/history/${encodeURIComponent(urlId)}/file`, {
-          method: 'DELETE'
-        });
-
-        if (!response.ok) {
-          const data = (await response.json().catch(() => ({}))) as { error?: string };
-          window.alert(data.error || '파일 삭제에 실패했습니다.');
-          button.disabled = false;
-          return;
-        }
-
-        const state = (await response.json().catch(() => null)) as Record<string, unknown> | null;
-        if (state) {
-          handleDownloadState(state);
-        } else {
-          button.disabled = false;
-        }
-      } catch (_error) {
-        window.alert('파일 삭제 중 오류가 발생했습니다.');
-        button.disabled = false;
-      }
-    });
-  });
-}
-
-function serializeHistoryClient(config: HistoryClientConfig): string {
-  return `(${historyClient.toString()})(${JSON.stringify(config)});`;
-}
-
-
-
-
-
-
 function buildPageLink(baseParams: URLSearchParams, overrides: Record<string, string | number | null | undefined>): string {
   const params = new URLSearchParams(baseParams);
   Object.entries(overrides).forEach(([key, value]) => {
@@ -519,6 +22,13 @@ function formatProgress(value: unknown): number {
   return Math.min(100, Math.max(0, Math.round(value as number)));
 }
 
+function getProgressFromItem(item: DownloadRecordRow & { percent?: number | null }): number {
+  if (Number.isFinite(item.percent)) {
+    return formatProgress(item.percent as number);
+  }
+  return item.status === 'completed' ? 100 : 0;
+}
+
 const ProgressCell: React.FC<{ progress: number }> = ({ progress }) => (
   <div className="progress-wrapper" role="progressbar" aria-valuenow={progress} aria-valuemin={0} aria-valuemax={100}>
     <div className="progress-track">
@@ -528,16 +38,38 @@ const ProgressCell: React.FC<{ progress: number }> = ({ progress }) => (
   </div>
 );
 
-const ActionsCell: React.FC<{ item: DownloadRecordRow; downloadTitle: string; downloadDisabled: boolean; urlId: string }> = ({
+interface ActionsCellProps {
+  item: DownloadRecordRow;
+  downloadTitle: string;
+  downloadDisabled: boolean;
+  urlId: string;
+  isDownloadPending?: boolean;
+  isStopPending?: boolean;
+  isResumePending?: boolean;
+  isRemovePending?: boolean;
+  isDeletePending?: boolean;
+}
+
+const ActionsCell: React.FC<ActionsCellProps> = ({
   item,
   downloadTitle,
   downloadDisabled,
-  urlId
+  urlId,
+  isDownloadPending,
+  isStopPending,
+  isResumePending,
+  isRemovePending,
+  isDeletePending
 }) => {
   const status = item.status || '';
   const isActive = status === 'downloading' || status === 'queued';
-  const canDownload = !downloadDisabled;
   const fileExists = Boolean(item.filePath);
+  const downloadBusy = Boolean(isDownloadPending);
+  const stopBusy = Boolean(isStopPending);
+  const resumeBusy = Boolean(isResumePending);
+  const removeBusy = Boolean(isRemovePending);
+  const deleteBusy = Boolean(isDeletePending);
+  const canDownload = !downloadDisabled && !downloadBusy;
 
   return (
     <>
@@ -546,7 +78,7 @@ const ActionsCell: React.FC<{ item: DownloadRecordRow; downloadTitle: string; do
         data-url-id={urlId}
         title="다운로드 정지"
         aria-label="다운로드 정지"
-        disabled={!isActive}
+        disabled={!isActive || stopBusy}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M8 5h3v14H8zm5 0h3v14h-3z" />
@@ -557,7 +89,7 @@ const ActionsCell: React.FC<{ item: DownloadRecordRow; downloadTitle: string; do
         data-url-id={urlId}
         title="다운로드 재시작"
         aria-label="다운로드 재시작"
-        disabled={isActive}
+        disabled={isActive || resumeBusy}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M8 5v14l11-7z" />
@@ -569,7 +101,10 @@ const ActionsCell: React.FC<{ item: DownloadRecordRow; downloadTitle: string; do
         title={downloadTitle}
         aria-label={downloadTitle}
         disabled={!canDownload}
+        data-loading={downloadBusy ? 'true' : undefined}
+        aria-busy={downloadBusy ? 'true' : undefined}
       >
+        <span className="spinner" aria-hidden="true" />
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M5 20h14v-2H5v2zm7-18l-5.5 6h3.5v6h4v-6H17L12 2z" />
         </svg>
@@ -579,14 +114,20 @@ const ActionsCell: React.FC<{ item: DownloadRecordRow; downloadTitle: string; do
         data-url-id={urlId}
         title={fileExists ? '파일만 삭제' : '삭제할 파일이 없습니다.'}
         aria-label="파일 삭제"
-        disabled={!fileExists}
+        disabled={!fileExists || removeBusy}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" />
           <path d="M10 11h1.5v6H10zm2.5 0H14v6h-1.5z" />
         </svg>
       </button>
-      <button className="icon-button delete-button" data-url-id={urlId} title="이력 삭제" aria-label="이력 삭제">
+      <button
+        className="icon-button delete-button"
+        data-url-id={urlId}
+        title="이력 삭제"
+        aria-label="이력 삭제"
+        disabled={deleteBusy}
+      >
         <svg viewBox="0 0 24 24" aria-hidden="true">
           <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" />
         </svg>
@@ -595,7 +136,7 @@ const ActionsCell: React.FC<{ item: DownloadRecordRow; downloadTitle: string; do
   );
 };
 
-const TableRow: React.FC<{ item: DownloadRecordRow }> = ({ item }) => {
+const TableRow: React.FC<{ item: DownloadRecordRow & { percent?: number | null } }> = ({ item }) => {
   const title = item.title?.trim() || '';
   const urlId = item.urlId || '';
   const status = item.status || 'unknown';
@@ -606,7 +147,7 @@ const TableRow: React.FC<{ item: DownloadRecordRow }> = ({ item }) => {
   const sourceUrl = item.url || '';
   const urlDisplay = sourceUrl || urlId || '';
   const statusClass = `status-badge status-${status}`;
-  const progressValue = item.status === 'completed' ? 100 : 0;
+  const progressValue = getProgressFromItem(item);
   const downloadDisabled = !fileAvailable || status !== 'completed';
   const downloadTitle = downloadDisabled ? '완료된 항목만 다운로드할 수 있습니다.' : '파일 다운로드';
 
@@ -651,7 +192,7 @@ const TableRow: React.FC<{ item: DownloadRecordRow }> = ({ item }) => {
   );
 };
 
-const HistoryTable: React.FC<{ items: DownloadRecordRow[] }> = ({ items }) => (
+const HistoryTable: React.FC<{ items: (DownloadRecordRow & { percent?: number | null })[] }> = ({ items }) => (
   <table role="grid">
     <thead>
       <tr>
@@ -735,8 +276,70 @@ const SearchForm: React.FC<{ searchTerm?: string }> = ({ searchTerm }) => (
   </form>
 );
 
+const HistoryAppShell: React.FC<HistoryPageProps> = ({
+  items,
+  total,
+  page,
+  pageSize,
+  totalPages,
+  showingFrom,
+  showingTo,
+  searchTerm
+}) => (
+  <>
+    <div className="card">
+      <h1>다운로드 이력</h1>
+      <div className="toolbar">
+        <SearchForm searchTerm={searchTerm} />
+        <div className="toolbar-actions">
+          <button type="button" className="secondary" data-action="refresh">
+            새로고침
+          </button>
+          <button type="button" className="primary" data-action="open-add-dialog">
+            다운로드 추가
+          </button>
+        </div>
+      </div>
+      <HistoryTable items={items} />
+      <div className="summary">
+        <span>
+          총 {total.toLocaleString()}건 중 {showingFrom.toLocaleString()}-{showingTo.toLocaleString()} 표시
+        </span>
+        <Pagination page={page} totalPages={totalPages} pageSize={pageSize} searchTerm={searchTerm} />
+      </div>
+    </div>
+    <AddDownloadDialog />
+  </>
+);
+
+const AddDownloadDialog: React.FC = () => (
+  <div className="dialog-backdrop" data-dialog="add-download" hidden>
+    <div className="dialog" role="dialog" aria-modal="true" aria-labelledby="add-download-title">
+      <h2 id="add-download-title">다운로드 추가</h2>
+      <p>다운로드할 영상의 URL을 입력하세요.</p>
+      <form data-form="add-download">
+        <label htmlFor="download-url" className="visually-hidden">
+          다운로드 URL
+        </label>
+        <input type="url" id="download-url" name="url" placeholder="https://" required />
+        <p className="form-helper" data-error-message hidden>
+          유효한 URL을 입력해주세요.
+        </p>
+        <div className="dialog-buttons">
+          <button type="button" className="secondary" data-action="cancel-dialog">
+            취소
+          </button>
+          <button type="submit" className="primary">
+            다운로드 요청
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+);
+
 export interface HistoryPageProps {
-  items: DownloadRecordRow[];
+  items: (DownloadRecordRow & { percent?: number | null })[];
   total: number;
   page: number;
   pageSize: number;
@@ -747,17 +350,11 @@ export interface HistoryPageProps {
   wsPath: string;
 }
 
-export const HistoryPage: React.FC<HistoryPageProps> = ({
-  items,
-  total,
-  page,
-  pageSize,
-  totalPages,
-  showingFrom,
-  showingTo,
-  searchTerm,
-  wsPath
-}) => (
+function escapeJsonForScript(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003C');
+}
+
+export const HistoryPage: React.FC<HistoryPageProps> = (props) => (
   <html lang="ko">
     <head>
       <meta charSet="UTF-8" />
@@ -765,52 +362,18 @@ export const HistoryPage: React.FC<HistoryPageProps> = ({
       <title>다운로드 이력</title>
       <link rel="stylesheet" href="/history/assets/history-page.css" />
     </head>
-    <body data-ws-path={wsPath || '/'}>
-      <div className="card">
-        <h1>다운로드 이력</h1>
-        <div className="toolbar">
-          <SearchForm searchTerm={searchTerm} />
-          <div className="toolbar-actions">
-            <button type="button" className="secondary" data-action="refresh">
-              새로고침
-            </button>
-            <button type="button" className="primary" data-action="open-add-dialog">
-              다운로드 추가
-            </button>
-          </div>
-        </div>
-        <HistoryTable items={items} />
-        <div className="summary">
-          <span>
-            총 {total.toLocaleString()}건 중 {showingFrom.toLocaleString()}-{showingTo.toLocaleString()} 표시
-          </span>
-          <Pagination page={page} totalPages={totalPages} pageSize={pageSize} searchTerm={searchTerm} />
-        </div>
+    <body data-ws-path={props.wsPath || '/'}>
+      <div id="history-root">
+        <HistoryAppShell {...props} />
       </div>
-      <div className="dialog-backdrop" data-dialog="add-download" hidden>
-        <div className="dialog" role="dialog" aria-modal="true" aria-labelledby="add-download-title">
-          <h2 id="add-download-title">다운로드 추가</h2>
-          <p>다운로드할 영상의 URL을 입력하세요.</p>
-          <form data-form="add-download">
-            <label htmlFor="download-url" className="visually-hidden">
-              다운로드 URL
-            </label>
-            <input type="url" id="download-url" name="url" placeholder="https://" required />
-            <p className="form-helper" data-error-message hidden>
-              유효한 URL을 입력해주세요.
-            </p>
-            <div className="dialog-buttons">
-              <button type="button" className="secondary" data-action="cancel-dialog">
-                취소
-              </button>
-              <button type="submit" className="primary">
-                다운로드 요청
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-      <script dangerouslySetInnerHTML={{ __html: serializeHistoryClient({ wsPath }) }} />
+      <script
+        id="history-props"
+        type="application/json"
+        dangerouslySetInnerHTML={{ __html: escapeJsonForScript(props) }}
+      />
+      <script src="/history/assets/react.production.min.js"></script>
+      <script src="/history/assets/react-dom.production.min.js"></script>
+      <script src="/history/assets/history-client.js"></script>
     </body>
   </html>
 );

--- a/server/src/history-page.css
+++ b/server/src/history-page.css
@@ -208,6 +208,24 @@ tbody tr:hover {
   fill: currentColor;
 }
 
+.icon-button .spinner {
+  display: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: history-download-spin 0.8s linear infinite;
+}
+
+.icon-button[data-loading="true"] .spinner {
+  display: inline-block;
+}
+
+.icon-button[data-loading="true"] svg {
+  display: none;
+}
+
 .icon-button.download-button {
   color: #2563eb;
 }
@@ -375,6 +393,15 @@ tbody tr:hover {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+@keyframes history-download-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 768px) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import { loadConfig, ServerConfig } from './config';
 import { DownloadManager, DownloadSnapshot } from './download-manager';
 import { createWebSocketServer, handleUpgrade, WebSocket } from './websocket-server';
-import { getHistoryPageCss } from './history-page-assets';
+import { getHistoryClientScript, getHistoryPageCss, getReactDomUmdScript, getReactUmdScript } from './history-page-assets';
 import {
     initDatabase,
     ensureUrlIds,
@@ -582,6 +582,36 @@ const server = http.createServer((req, res) => {
             'Cache-Control': 'public, max-age=300'
         });
         res.end(css);
+        return;
+    }
+
+    if (req.method === 'GET' && parsedUrl.pathname === '/history/assets/react.production.min.js') {
+        const script = getReactUmdScript();
+        res.writeHead(200, {
+            'Content-Type': 'application/javascript; charset=utf-8',
+            'Cache-Control': 'public, max-age=300'
+        });
+        res.end(script);
+        return;
+    }
+
+    if (req.method === 'GET' && parsedUrl.pathname === '/history/assets/react-dom.production.min.js') {
+        const script = getReactDomUmdScript();
+        res.writeHead(200, {
+            'Content-Type': 'application/javascript; charset=utf-8',
+            'Cache-Control': 'public, max-age=300'
+        });
+        res.end(script);
+        return;
+    }
+
+    if (req.method === 'GET' && parsedUrl.pathname === '/history/assets/history-client.js') {
+        const clientScript = getHistoryClientScript();
+        res.writeHead(200, {
+            'Content-Type': 'application/javascript; charset=utf-8',
+            'Cache-Control': 'public, max-age=120'
+        });
+        res.end(clientScript);
         return;
     }
 


### PR DESCRIPTION
## Summary
- replace the imperative history page bootstrap with a React-powered client that manages dialog state, websocket updates, and download actions while showing a spinner during downloads
- serve the React and history client scripts from the server so the page can hydrate in the browser
- add CSS for the download spinner to visually communicate in-progress work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbc22a32d0832684dcf99a2d16a1b3