### PR TITLE
Add inline playback streaming window

### DIFF
--- a/server/src/history-page.css
+++ b/server/src/history-page.css
@@ -480,6 +480,10 @@ input {
     color: #2563eb;
 }
 
+.play-button {
+    color: #14b8a6;
+}
+
 .remove-file-button {
     color: #f59e0b;
 }
@@ -517,6 +521,147 @@ input {
 
 .history-card-row + .history-card-row {
     margin-top: 16px;
+}
+
+.playback-window {
+    position: fixed;
+    z-index: 1600;
+    background: #0f172a;
+    color: #f8fafc;
+    border-radius: 18px;
+    box-shadow: 0 22px 48px rgba(15, 23, 42, 0.32);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-width: 260px;
+    min-height: 146px;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    user-select: none;
+}
+
+.playback-window--dragging .playback-window__header {
+    cursor: grabbing;
+    background: rgba(15, 23, 42, 0.92);
+}
+
+.playback-window--resizing .playback-window__resize-handle {
+    opacity: 1;
+}
+
+.playback-window__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    background: rgba(15, 23, 42, 0.86);
+    cursor: grab;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.playback-window__title {
+    flex: 1;
+    font-size: 0.9rem;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.playback-window__header-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.playback-window__icon-button {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: #e2e8f0;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.playback-window__icon-button[href] {
+    text-decoration: none;
+}
+
+.playback-window__icon-button svg {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+}
+
+.playback-window__icon-button:hover,
+.playback-window__icon-button:focus-visible {
+    background: rgba(99, 102, 241, 0.16);
+    border-color: rgba(99, 102, 241, 0.32);
+    outline: none;
+}
+
+.playback-window__icon-button:focus-visible {
+    box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.3);
+}
+
+.playback-window__close {
+    color: #f87171;
+}
+
+.playback-window__body {
+    flex: 1;
+    position: relative;
+    background: #0b1120;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.playback-window__video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background: #000;
+}
+
+.playback-window__error {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.playback-window__resize-handle {
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    right: 8px;
+    bottom: 8px;
+    cursor: nwse-resize;
+    opacity: 0.7;
+}
+
+.playback-window__resize-handle::before {
+    content: '';
+    position: absolute;
+    inset: 2px;
+    border-right: 2px solid rgba(148, 163, 184, 0.7);
+    border-bottom: 2px solid rgba(148, 163, 184, 0.7);
+    border-radius: 2px;
+}
+
+.playback-window--error .playback-window__body {
+    background: rgba(15, 23, 42, 0.9);
+}
+
+.playback-window--error .playback-window__icon-button {
+    color: #fbbf24;
 }
 
 .history-card-wrapper {

--- a/server/src/history-page/client/components/HistoryApp.tsx
+++ b/server/src/history-page/client/components/HistoryApp.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { HistoryTable } from '../../components/HistoryTable.js';
 import { Pagination } from '../../components/Pagination.js';
 import { SearchForm } from '../../components/SearchForm.js';
 import type { HistoryPageBootstrap } from '../types.js';
 import { AddDownloadDialog } from './AddDownloadDialog.js';
 import { HistoryCardList } from '../../components/HistoryCardList.js';
+import { PlaybackWindow } from './PlaybackWindow.js';
 import { useBusyMap } from '../hooks/useBusyMap.js';
 import { useDialogState } from '../hooks/useDialogState.js';
 import { useHistoryWebSocket } from '../hooks/useHistoryWebSocket.js';
@@ -29,6 +30,12 @@ function toBooleanMap(source: Record<string, boolean>): Record<string, boolean> 
     return { ...source };
 }
 
+interface PlaybackSession {
+    urlId: string;
+    title: string;
+    cacheKey: number;
+}
+
 export const HistoryApp: FC<HistoryAppProps> = (props) => {
     const [items, setItems] = useState<HistoryItem[]>(() => cloneItems(props.items));
     const downloadBusy = useBusyMap();
@@ -37,6 +44,7 @@ export const HistoryApp: FC<HistoryAppProps> = (props) => {
     const removeBusy = useBusyMap();
     const deleteBusy = useBusyMap();
     const formatBusy = useBusyMap();
+    const [playback, setPlayback] = useState<PlaybackSession | null>(null);
 
     const dialog = useDialogState(props.checkFormatList);
     const dialogState = dialog.state;
@@ -495,6 +503,63 @@ export const HistoryApp: FC<HistoryAppProps> = (props) => {
 
     useHistoryWebSocket(props.wsPath, updateItemState);
 
+    const handlePlay = useCallback(
+        (urlId: string) => {
+            const item = items.find((entry) => entry.urlId === urlId);
+            if (!item || !item.filePath) {
+                window.alert('재생할 수 있는 파일이 없습니다. 다운로드가 완료되었는지 확인해주세요.');
+                return;
+            }
+
+            const safeTitle = item.title?.trim() || '(제목 없음)';
+            setPlayback({ urlId, title: safeTitle, cacheKey: Date.now() });
+        },
+        [items]
+    );
+
+    const handleClosePlayback = useCallback(() => {
+        setPlayback(null);
+    }, []);
+
+    const handleReloadPlayback = useCallback(() => {
+        setPlayback((previous) => (previous ? { ...previous, cacheKey: Date.now() } : previous));
+    }, []);
+
+    useEffect(() => {
+        if (!playback) {
+            return;
+        }
+        setPlayback((previous) => {
+            if (!previous) {
+                return previous;
+            }
+            const item = items.find((entry) => entry.urlId === previous.urlId);
+            if (!item || !item.filePath) {
+                return null;
+            }
+            const nextTitle = item.title?.trim() || '(제목 없음)';
+            if (nextTitle !== previous.title) {
+                return { ...previous, title: nextTitle };
+            }
+            return previous;
+        });
+    }, [items, playback?.urlId]);
+
+    const playbackStreamUrl = useMemo(() => {
+        if (!playback) {
+            return '';
+        }
+        const base = `/history/${encodeURIComponent(playback.urlId)}/stream`;
+        return `${base}?v=${playback.cacheKey}`;
+    }, [playback]);
+
+    const playbackDownloadUrl = useMemo(() => {
+        if (!playback) {
+            return '';
+        }
+        return `/history/${encodeURIComponent(playback.urlId)}/file`;
+    }, [playback]);
+
     const summary = useMemo(
         () => ({
             total: props.total,
@@ -556,7 +621,8 @@ export const HistoryApp: FC<HistoryAppProps> = (props) => {
                                     onRemoveFile: handleRemoveFile,
                                     onDelete: handleDelete,
                                     onSelectFormat: handleFormatSelectionRequest,
-                                    onOpenBrowser: handleOpenBrowser
+                                    onOpenBrowser: handleOpenBrowser,
+                                    onPlay: handlePlay
                                 }}
                                 pending={{
                                     download: toBooleanMap(downloadBusy.state),
@@ -582,7 +648,8 @@ export const HistoryApp: FC<HistoryAppProps> = (props) => {
                                 onRemoveFile: handleRemoveFile,
                                 onDelete: handleDelete,
                                 onSelectFormat: handleFormatSelectionRequest,
-                                onOpenBrowser: handleOpenBrowser
+                                onOpenBrowser: handleOpenBrowser,
+                                onPlay: handlePlay
                             }}
                             pending={{
                                 download: toBooleanMap(downloadBusy.state),
@@ -625,6 +692,16 @@ export const HistoryApp: FC<HistoryAppProps> = (props) => {
                 onSelectFormat={dialog.selectFormat}
                 onBack={dialogState.mode === 'format' ? dialog.backToUrl : undefined}
             />
+            {playback ? (
+                <PlaybackWindow
+                    urlId={playback.urlId}
+                    title={playback.title}
+                    streamUrl={playbackStreamUrl}
+                    downloadUrl={playbackDownloadUrl}
+                    onClose={handleClosePlayback}
+                    onReload={handleReloadPlayback}
+                />
+            ) : null}
         </>
     );
 };

--- a/server/src/history-page/client/components/PlaybackWindow.tsx
+++ b/server/src/history-page/client/components/PlaybackWindow.tsx
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type FC } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+interface PlaybackWindowProps {
+    title: string;
+    streamUrl: string;
+    urlId: string;
+    onClose: () => void;
+    onReload?: () => void;
+    downloadUrl?: string;
+}
+
+interface Position {
+    top: number;
+    left: number;
+}
+
+interface Dimensions {
+    width: number;
+    height: number;
+}
+
+const MIN_WIDTH = 260;
+const MIN_HEIGHT = 146;
+const MAX_WIDTH = 960;
+const MAX_HEIGHT = 720;
+const VIEWPORT_MARGIN = 16;
+const DEFAULT_DIMENSIONS: Dimensions = { width: 360, height: 202 };
+
+function clampDimensions(candidate: Dimensions): Dimensions {
+    if (typeof window === 'undefined') {
+        return {
+            width: Math.max(MIN_WIDTH, candidate.width),
+            height: Math.max(MIN_HEIGHT, candidate.height)
+        };
+    }
+
+    const maxWidth = Math.max(MIN_WIDTH, Math.min(window.innerWidth - VIEWPORT_MARGIN * 2, MAX_WIDTH));
+    const maxHeight = Math.max(MIN_HEIGHT, Math.min(window.innerHeight - VIEWPORT_MARGIN * 2, MAX_HEIGHT));
+
+    return {
+        width: Math.min(Math.max(MIN_WIDTH, candidate.width), maxWidth),
+        height: Math.min(Math.max(MIN_HEIGHT, candidate.height), maxHeight)
+    };
+}
+
+function clampPosition(candidate: Position, size: Dimensions): Position {
+    if (typeof window === 'undefined') {
+        return candidate;
+    }
+
+    const maxLeft = Math.max(VIEWPORT_MARGIN, window.innerWidth - size.width - VIEWPORT_MARGIN);
+    const maxTop = Math.max(VIEWPORT_MARGIN, window.innerHeight - size.height - VIEWPORT_MARGIN);
+
+    return {
+        top: Math.min(Math.max(VIEWPORT_MARGIN, candidate.top), maxTop),
+        left: Math.min(Math.max(VIEWPORT_MARGIN, candidate.left), maxLeft)
+    };
+}
+
+function computeInitialPosition(size: Dimensions): Position {
+    if (typeof window === 'undefined') {
+        return { top: VIEWPORT_MARGIN, left: VIEWPORT_MARGIN };
+    }
+
+    const top = Math.max(VIEWPORT_MARGIN, window.innerHeight - size.height - VIEWPORT_MARGIN);
+    const left = Math.max(VIEWPORT_MARGIN, window.innerWidth - size.width - VIEWPORT_MARGIN);
+    return { top, left };
+}
+
+export const PlaybackWindow: FC<PlaybackWindowProps> = ({
+    title,
+    streamUrl,
+    urlId,
+    onClose,
+    onReload,
+    downloadUrl
+}) => {
+    const [dimensions, setDimensions] = useState<Dimensions>(() => clampDimensions(DEFAULT_DIMENSIONS));
+    const [position, setPosition] = useState<Position>(() => clampPosition(computeInitialPosition(DEFAULT_DIMENSIONS), DEFAULT_DIMENSIONS));
+    const [isDragging, setIsDragging] = useState(false);
+    const [isResizing, setIsResizing] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [videoElement, setVideoElement] = useState<HTMLVideoElement | null>(null);
+    const dragCleanupRef = useRef<(() => void) | null>(null);
+    const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        const handleWindowResize = () => {
+            setDimensions((prev) => {
+                const next = clampDimensions(prev);
+                setPosition((current) => clampPosition(current, next));
+                return next;
+            });
+        };
+
+        window.addEventListener('resize', handleWindowResize);
+        return () => {
+            window.removeEventListener('resize', handleWindowResize);
+        };
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            dragCleanupRef.current?.();
+            resizeCleanupRef.current?.();
+        };
+    }, []);
+
+    useEffect(() => {
+        setPosition((current) => clampPosition(current, dimensions));
+    }, [dimensions]);
+
+    useEffect(() => {
+        setErrorMessage(null);
+    }, [streamUrl]);
+
+    const handlePointerMoveDrag = useCallback(
+        (initialPosition: Position, startX: number, startY: number) => (event: PointerEvent) => {
+            event.preventDefault();
+            const deltaX = event.clientX - startX;
+            const deltaY = event.clientY - startY;
+            const nextPosition = clampPosition(
+                {
+                    top: initialPosition.top + deltaY,
+                    left: initialPosition.left + deltaX
+                },
+                dimensions
+            );
+            setPosition(nextPosition);
+        },
+        [dimensions]
+    );
+
+    const handlePointerMoveResize = useCallback(
+        (initialSize: Dimensions, startX: number, startY: number) => (event: PointerEvent) => {
+            event.preventDefault();
+            const deltaX = event.clientX - startX;
+            const deltaY = event.clientY - startY;
+            const nextSize = clampDimensions({
+                width: initialSize.width + deltaX,
+                height: initialSize.height + deltaY
+            });
+            setDimensions(nextSize);
+            setPosition((current) => clampPosition(current, nextSize));
+        },
+        []
+    );
+
+    const startDrag = useCallback(
+        (event: ReactPointerEvent<HTMLDivElement>) => {
+            if (event.pointerType === 'mouse' && event.button !== 0) {
+                return;
+            }
+            event.preventDefault();
+            dragCleanupRef.current?.();
+            const initialPosition = { ...position };
+            const startX = event.clientX;
+            const startY = event.clientY;
+            setIsDragging(true);
+            const moveListener = handlePointerMoveDrag(initialPosition, startX, startY);
+            const stopDragging = () => {
+                window.removeEventListener('pointermove', moveListener);
+                window.removeEventListener('pointerup', stopDragging);
+                window.removeEventListener('pointercancel', stopDragging);
+                setIsDragging(false);
+                if (dragCleanupRef.current === stopDragging) {
+                    dragCleanupRef.current = null;
+                }
+            };
+            window.addEventListener('pointermove', moveListener);
+            window.addEventListener('pointerup', stopDragging);
+            window.addEventListener('pointercancel', stopDragging);
+            dragCleanupRef.current = stopDragging;
+        },
+        [handlePointerMoveDrag, position]
+    );
+
+    const startResize = useCallback(
+        (event: ReactPointerEvent<HTMLDivElement>) => {
+            if (event.pointerType === 'mouse' && event.button !== 0) {
+                return;
+            }
+            event.preventDefault();
+            resizeCleanupRef.current?.();
+            const initialSize = { ...dimensions };
+            const startX = event.clientX;
+            const startY = event.clientY;
+            setIsResizing(true);
+            const moveListener = handlePointerMoveResize(initialSize, startX, startY);
+            const stopResizing = () => {
+                window.removeEventListener('pointermove', moveListener);
+                window.removeEventListener('pointerup', stopResizing);
+                window.removeEventListener('pointercancel', stopResizing);
+                setIsResizing(false);
+                if (resizeCleanupRef.current === stopResizing) {
+                    resizeCleanupRef.current = null;
+                }
+            };
+            window.addEventListener('pointermove', moveListener);
+            window.addEventListener('pointerup', stopResizing);
+            window.addEventListener('pointercancel', stopResizing);
+            resizeCleanupRef.current = stopResizing;
+        },
+        [dimensions, handlePointerMoveResize]
+    );
+
+    const handleVideoError = useCallback(() => {
+        setErrorMessage('동영상을 재생할 수 없습니다. 파일이 삭제되었는지 확인해주세요.');
+    }, []);
+
+    const handleVideoCanPlay = useCallback(() => {
+        setErrorMessage(null);
+    }, []);
+
+    const tryAutoplay = useCallback((video: HTMLVideoElement | null) => {
+        if (!video) {
+            return;
+        }
+        const playPromise = video.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+            playPromise.catch(() => {
+                // Autoplay was likely prevented; the user can start playback manually.
+            });
+        }
+    }, []);
+
+    const handleVideoRef = useCallback((node: HTMLVideoElement | null) => {
+        setVideoElement(node);
+    }, []);
+
+    useEffect(() => {
+        if (videoElement) {
+            tryAutoplay(videoElement);
+        }
+    }, [tryAutoplay, videoElement, streamUrl]);
+
+    const containerClassName = useMemo(() => {
+        const classes = ['playback-window'];
+        if (isDragging) {
+            classes.push('playback-window--dragging');
+        }
+        if (isResizing) {
+            classes.push('playback-window--resizing');
+        }
+        if (errorMessage) {
+            classes.push('playback-window--error');
+        }
+        return classes.join(' ');
+    }, [errorMessage, isDragging, isResizing]);
+
+    const videoId = useMemo(() => `playback-video-${urlId}`, [urlId]);
+
+    return (
+        <div
+            className={containerClassName}
+            data-url-id={urlId}
+            style={{
+                width: `${dimensions.width}px`,
+                height: `${dimensions.height}px`,
+                top: `${position.top}px`,
+                left: `${position.left}px`
+            }}
+        >
+            <div className="playback-window__header" onPointerDown={startDrag} role="presentation">
+                <div className="playback-window__title" title={title || '(제목 없음)'}>
+                    {title || '(제목 없음)'}
+                </div>
+                <div className="playback-window__header-actions">
+                    {downloadUrl ? (
+                        <a
+                            className="playback-window__icon-button"
+                            href={downloadUrl}
+                            title="파일 다운로드"
+                            aria-label="파일 다운로드"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M11 5h2v8h3l-4 4-4-4h3z" />
+                                <path d="M5 19h14v2H5z" />
+                            </svg>
+                        </a>
+                    ) : null}
+                    {onReload ? (
+                        <button
+                            type="button"
+                            className="playback-window__icon-button"
+                            title="다시 불러오기"
+                            aria-label="다시 불러오기"
+                            onClick={onReload}
+                        >
+                            <svg viewBox="0 0 24 24" aria-hidden="true">
+                                <path d="M12 6a6 6 0 1 0 5.918 5.071l1.97.353A8 8 0 1 1 12 4v2z" />
+                                <path d="M20 4v6h-6l2.146-2.146A6.002 6.002 0 0 0 12 6V4a8.002 8.002 0 0 1 6.854 3.77z" />
+                            </svg>
+                        </button>
+                    ) : null}
+                    <button
+                        type="button"
+                        className="playback-window__icon-button playback-window__close"
+                        title="창 닫기"
+                        aria-label="창 닫기"
+                        onClick={onClose}
+                    >
+                        <svg viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M18.3 5.71 12 12l6.3 6.29-1.42 1.42L10.59 13.4 4.3 19.71 2.89 18.3 9.17 12 2.89 5.71 4.3 4.29l6.29 6.3 6.29-6.3z" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div className="playback-window__body">
+                {errorMessage ? (
+                    <div className="playback-window__error" role="alert">
+                        <p>{errorMessage}</p>
+                        {onReload ? (
+                            <button type="button" className="button button--primary" onClick={onReload}>
+                                다시 시도
+                            </button>
+                        ) : null}
+                    </div>
+                ) : (
+                    <video
+                        id={videoId}
+                        key={streamUrl}
+                        className="playback-window__video"
+                        src={streamUrl}
+                        controls
+                        playsInline
+                        ref={handleVideoRef}
+                        onCanPlay={handleVideoCanPlay}
+                        onError={handleVideoError}
+                    />
+                )}
+            </div>
+            <div className="playback-window__resize-handle" role="presentation" onPointerDown={startResize} />
+        </div>
+    );
+};
+

--- a/server/src/history-page/components/ActionsCell.tsx
+++ b/server/src/history-page/components/ActionsCell.tsx
@@ -18,6 +18,7 @@ export interface ActionsCellHandlers {
     onDelete?: (urlId: string) => void;
     onSelectFormat?: (urlId: string) => void;
     onOpenBrowser?: (url: string) => void;
+    onPlay?: (urlId: string) => void;
 }
 
 interface ActionsCellProps extends ActionsCellHandlers, ActionsCellState {
@@ -39,6 +40,7 @@ export const ActionsCell: React.FC<ActionsCellProps> = ({
     onRemoveFile,
     onDelete,
     onSelectFormat,
+    onPlay,
     enableFormatSelection,
     isDownloadPending,
     isStopPending,
@@ -87,6 +89,8 @@ export const ActionsCell: React.FC<ActionsCellProps> = ({
         ? handleClick(onSelectFormat)
         : handleClick(onDownload);
 
+    const handlePlay = handleClick(onPlay);
+
     return (
         <>
             <button
@@ -126,6 +130,18 @@ export const ActionsCell: React.FC<ActionsCellProps> = ({
                 <span className="spinner" aria-hidden="true" />
                 <svg viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M11.292 16.706a1 1 0 0 0 1.416 0l3-3a1 1 0 0 0-1.414-1.414L13 13.586V4a1 1 0 0 0-2 0v9.586l-1.293-1.293a1 1 0 0 0-1.414 1.414zM17 19H7a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"/>
+                </svg>
+            </button>
+            <button
+                className="icon-button play-button"
+                data-url-id={urlId}
+                title={fileExists ? '파일 재생' : '재생할 파일이 없습니다.'}
+                aria-label="파일 재생"
+                disabled={!fileExists || Boolean(isFormatSelect)}
+                onClick={handlePlay}
+            >
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M8 5.14v13.72a1 1 0 0 0 1.52.85l11-6.86a1 1 0 0 0 0-1.7l-11-6.86A1 1 0 0 0 8 5.14z" />
                 </svg>
             </button>
             <button

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -122,6 +122,120 @@ function resolveWithinDownloadDir(filePath: string | null | undefined): string {
     return absolute;
 }
 
+class HistoryFileError extends Error {
+    public readonly statusCode: number;
+    public readonly payload: { error: string };
+
+    constructor(statusCode: number, message: string) {
+        super(message);
+        this.statusCode = statusCode;
+        this.payload = { error: message };
+        this.name = 'HistoryFileError';
+    }
+}
+
+type DownloadRecord = NonNullable<ReturnType<typeof getDownloadState>>;
+
+interface HistoryFileResolution {
+    record: DownloadRecord;
+    resolvedPath: string;
+    stats: fs.Stats;
+}
+
+async function resolveHistoryFileOrThrow(urlId: string): Promise<HistoryFileResolution> {
+    const record = getDownloadState(urlId);
+
+    if (!record) {
+        throw new HistoryFileError(404, '다운로드 정보를 찾을 수 없습니다.');
+    }
+
+    let resolved = resolveWithinDownloadDir(record.filePath);
+
+    if (!resolved) {
+        console.warn('[history] File download outside directory', { urlId, filePath: record.filePath });
+        throw new HistoryFileError(403, 'File outside of download directory');
+    }
+
+    let stats: fs.Stats;
+    try {
+        stats = await fs.promises.stat(resolved);
+    } catch (statError) {
+        const err = statError as NodeJS.ErrnoException;
+        if (err && err.code === 'ENOENT') {
+            const fallback = downloadManager.findExistingFileById(urlId);
+            if (!fallback) {
+                console.warn('[history] File download fallback not found', { urlId });
+                throw new HistoryFileError(404, 'File not found');
+            }
+
+            const normalisedFallback = resolveWithinDownloadDir(fallback);
+            if (!normalisedFallback) {
+                console.warn('[history] File download fallback outside directory', { urlId, fallback });
+                throw new HistoryFileError(403, 'File outside of download directory');
+            }
+
+            try {
+                stats = await fs.promises.stat(normalisedFallback);
+                resolved = normalisedFallback;
+                const relative = path.relative(config.downloadDir, resolved);
+                const clientPath =
+                    relative && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : resolved;
+                recordDownloadFilePath({
+                    urlId,
+                    filePath: clientPath,
+                    fileSizeBytes: stats.size
+                });
+            } catch (fallbackError) {
+                const fallbackErr = fallbackError as NodeJS.ErrnoException;
+                console.error('[history] File download fallback stat failed', {
+                    urlId,
+                    error: fallbackErr.message
+                });
+                throw new HistoryFileError(fallbackErr.code === 'ENOENT' ? 404 : 500, 'File not found');
+            }
+        } else {
+            console.error('[history] File stat failed', { urlId, error: err?.message });
+            throw new HistoryFileError(500, 'File not found');
+        }
+    }
+
+    return { record, resolvedPath: resolved, stats };
+}
+
+function getContentTypeForPath(filePath: string): string {
+    const extension = path.extname(filePath).toLowerCase();
+    switch (extension) {
+        case '.mp4':
+            return 'video/mp4';
+        case '.mkv':
+        case '.mk3d':
+        case '.mka':
+        case '.mks':
+            return 'video/x-matroska';
+        case '.webm':
+            return 'video/webm';
+        case '.mov':
+        case '.qt':
+            return 'video/quicktime';
+        case '.avi':
+            return 'video/x-msvideo';
+        case '.mp3':
+            return 'audio/mpeg';
+        case '.m4a':
+        case '.mp4a':
+            return 'audio/mp4';
+        case '.ogg':
+        case '.oga':
+            return 'audio/ogg';
+        case '.wav':
+            return 'audio/wav';
+        case '.flac':
+            return 'audio/flac';
+        default:
+            return 'application/octet-stream';
+    }
+}
+
 function isValidUrl(candidate: string): boolean {
     try {
         const parsed = new URL(candidate);
@@ -411,73 +525,16 @@ async function handleHistoryFileDownload(_req: IncomingMessage, res: ServerRespo
             return;
         }
 
-        const record = getDownloadState(urlId);
-        if (!record || !record.filePath) {
-            console.warn('[history] File download missing record', { urlId });
-            jsonResponse(res, 404, { error: 'File not available' });
-            return;
-        }
-
-        let resolved = resolveWithinDownloadDir(record.filePath);
-        if (!resolved) {
-            console.warn('[history] File download outside directory', { urlId, filePath: record.filePath });
-            jsonResponse(res, 403, { error: 'File outside of download directory' });
-            return;
-        }
-
-        let stats: fs.Stats;
-        try {
-            stats = await fs.promises.stat(resolved);
-        } catch (statError) {
-            const err = statError as NodeJS.ErrnoException;
-            if (err && err.code === 'ENOENT') {
-                const fallback = downloadManager.findExistingFileById(urlId);
-                if (!fallback) {
-                    console.warn('[history] File download fallback not found', { urlId });
-                    jsonResponse(res, 404, { error: 'File not found' });
-                    return;
-                }
-
-                const normalisedFallback = resolveWithinDownloadDir(fallback);
-                if (!normalisedFallback) {
-                    console.warn('[history] File download fallback outside directory', { urlId, fallback });
-                    jsonResponse(res, 403, { error: 'File outside of download directory' });
-                    return;
-                }
-
-                try {
-                    stats = await fs.promises.stat(normalisedFallback);
-                    resolved = normalisedFallback;
-                    const relative = path.relative(config.downloadDir, resolved);
-                    const clientPath =
-                        relative && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : resolved;
-                    recordDownloadFilePath({
-                        urlId,
-                        filePath: clientPath,
-                        fileSizeBytes: stats.size
-                    });
-                } catch (fallbackError) {
-                    const fallbackErr = fallbackError as NodeJS.ErrnoException;
-                    console.error('[history] File download fallback stat failed', { urlId, error: fallbackErr.message });
-                    jsonResponse(res, fallbackErr.code === 'ENOENT' ? 404 : 500, { error: 'File not found' });
-                    return;
-                }
-            } else {
-                console.error('[history] File stat failed', { urlId, error: err.message });
-                jsonResponse(res, 500, { error: 'File not found' });
-                return;
-            }
-        }
-
+        const { resolvedPath, stats } = await resolveHistoryFileOrThrow(urlId);
         res.writeHead(200, {
             'Content-Type': 'application/octet-stream',
             'Content-Length': stats.size,
-            'Content-Disposition': `attachment; filename="${encodeURIComponent(path.basename(resolved))}"`
+            'Content-Disposition': `attachment; filename="${encodeURIComponent(path.basename(resolvedPath))}"`
         });
 
-        const stream = fs.createReadStream(resolved);
+        const stream = fs.createReadStream(resolvedPath);
         stream.on('error', () => {
-            console.error('[history] File stream error', { urlId, filePath: resolved });
+            console.error('[history] File stream error', { urlId, filePath: resolvedPath });
             if (!res.headersSent) {
                 res.writeHead(500);
             }
@@ -485,8 +542,122 @@ async function handleHistoryFileDownload(_req: IncomingMessage, res: ServerRespo
         });
         stream.pipe(res);
     } catch (error) {
+        if (error instanceof HistoryFileError) {
+            jsonResponse(res, error.statusCode, error.payload);
+            return;
+        }
         const err = error as Error;
+        console.error('[history] handleHistoryFileDownload failed', { urlId, error: err.message });
         jsonResponse(res, 500, { error: err.message });
+    }
+}
+
+function writeStreamError(res: ServerResponse, stream: fs.ReadStream, context: Record<string, unknown>): void {
+    stream.on('error', () => {
+        console.error('[history] Stream error', context);
+        if (!res.headersSent) {
+            res.writeHead(500);
+        }
+        res.end();
+    });
+}
+
+async function handleHistoryFileStream(req: IncomingMessage, res: ServerResponse, urlId: string | undefined): Promise<void> {
+    try {
+        if (!urlId) {
+            jsonResponse(res, 400, { error: 'urlId is required' });
+            return;
+        }
+
+        const { resolvedPath, stats } = await resolveHistoryFileOrThrow(urlId);
+        const totalSize = Math.max(0, stats.size);
+        const contentType = getContentTypeForPath(resolvedPath);
+
+        if (totalSize === 0) {
+            res.writeHead(200, {
+                'Content-Type': contentType,
+                'Content-Length': 0,
+                'Accept-Ranges': 'bytes',
+                'Cache-Control': 'no-store'
+            });
+            res.end();
+            return;
+        }
+
+        const rangeHeader = req.headers.range;
+        if (rangeHeader) {
+            const match = /^bytes=(\d*)-(\d*)$/u.exec(rangeHeader.trim());
+            if (!match) {
+                res.writeHead(416, { 'Content-Range': `bytes */${totalSize}` });
+                res.end();
+                return;
+            }
+
+            let start: number;
+            let end: number;
+            const startRaw = match[1];
+            const endRaw = match[2];
+
+            if (startRaw === '' && endRaw !== '') {
+                const suffixLength = Number.parseInt(endRaw, 10);
+                if (!Number.isFinite(suffixLength) || suffixLength <= 0) {
+                    res.writeHead(416, { 'Content-Range': `bytes */${totalSize}` });
+                    res.end();
+                    return;
+                }
+                end = totalSize - 1;
+                start = Math.max(0, totalSize - suffixLength);
+            } else {
+                start = startRaw ? Number.parseInt(startRaw, 10) : 0;
+                end = endRaw ? Number.parseInt(endRaw, 10) : totalSize - 1;
+                if (!Number.isFinite(start) || !Number.isFinite(end)) {
+                    res.writeHead(416, { 'Content-Range': `bytes */${totalSize}` });
+                    res.end();
+                    return;
+                }
+            }
+
+            if (start < 0 || end < 0 || start > end || start >= totalSize) {
+                res.writeHead(416, { 'Content-Range': `bytes */${totalSize}` });
+                res.end();
+                return;
+            }
+
+            const safeEnd = Math.min(end, totalSize - 1);
+            const safeStart = Math.min(start, safeEnd);
+            const chunkSize = safeEnd - safeStart + 1;
+
+            res.writeHead(206, {
+                'Content-Type': contentType,
+                'Content-Length': chunkSize,
+                'Content-Range': `bytes ${safeStart}-${safeEnd}/${totalSize}`,
+                'Accept-Ranges': 'bytes',
+                'Cache-Control': 'no-store'
+            });
+
+            const stream = fs.createReadStream(resolvedPath, { start: safeStart, end: safeEnd });
+            writeStreamError(res, stream, { urlId, filePath: resolvedPath, start: safeStart, end: safeEnd });
+            stream.pipe(res);
+            return;
+        }
+
+        res.writeHead(200, {
+            'Content-Type': contentType,
+            'Content-Length': totalSize,
+            'Accept-Ranges': 'bytes',
+            'Cache-Control': 'no-store'
+        });
+        const stream = fs.createReadStream(resolvedPath);
+        writeStreamError(res, stream, { urlId, filePath: resolvedPath });
+        stream.pipe(res);
+    } catch (error) {
+        if (error instanceof HistoryFileError) {
+            jsonResponse(res, error.statusCode, error.payload);
+            return;
+        }
+        const err = error as Error;
+        console.error('[history] handleHistoryFileStream failed', { urlId, error: err.message });
+        jsonResponse(res, 500, { error: err.message || '재생을 시작할 수 없습니다.' });
     }
 }
 
@@ -761,9 +932,17 @@ const server = http.createServer((req, res) => {
 
     if (req.method === 'GET' && parsedUrl.pathname && parsedUrl.pathname.startsWith('/history/')) {
         const segments = parsedUrl.pathname.split('/').filter(Boolean);
-        if (segments.length === 3 && segments[2] === 'file') {
-            void handleHistoryFileDownload(req, res, decodeURIComponent(segments[1]));
-            return;
+        if (segments.length === 3) {
+            const action = segments[2];
+            const urlId = decodeURIComponent(segments[1]);
+            if (action === 'file') {
+                void handleHistoryFileDownload(req, res, urlId);
+                return;
+            }
+            if (action === 'stream') {
+                void handleHistoryFileStream(req, res, urlId);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add a play control to history entries and manage playback state in the client
- introduce a draggable, resizable playback window that streams completed files inline
- expose a ranged `/history/:id/stream` endpoint so the PiP player can request media slices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2d4431308326acbdd95a831ceb56