### PR TITLE
Add authentik login gate to web dashboard

### DIFF
--- a/web-version/README.md
+++ b/web-version/README.md
@@ -40,6 +40,16 @@ This folder hosts a lightweight HTTP + WebSocket service that coordinates YouTub
    | `DOCKER_BIN` | Docker CLI binary to call when running downloads in a container. |
    | `SERVER_CONTAINER_NAME` | Name of the running server container (used for sharing volumes with download containers). |
    | `HOST_DOWNLOAD_DIR` | (Compose only) Host folder that maps to the container's download directory. |
+   | `AUTHENTIK_DISCOVERY_URL` | Optional explicit OIDC discovery URL for authentik. |
+   | `AUTHENTIK_BASE_URL` | Base URL of your authentik instance, used with `AUTHENTIK_APPLICATION_SLUG` when discovery URL is not set. |
+   | `AUTHENTIK_APPLICATION_SLUG` | authentik application slug used to derive the OIDC discovery document. |
+   | `AUTHENTIK_CLIENT_ID` | OIDC client ID issued by authentik. |
+   | `AUTHENTIK_CLIENT_SECRET` | OIDC client secret issued by authentik. |
+   | `AUTHENTIK_PUBLIC_ORIGIN` | Public origin where this app is served, used for the callback URL. Example: `https://tracker.example.com`. |
+   | `AUTH_SESSION_SECRET` | Secret used to sign the local session cookie. |
+   | `AUTHENTIK_SCOPES` | Optional scopes list. Defaults to `openid profile email`. |
+   | `AUTH_SESSION_TTL_SECONDS` | Optional signed-session lifetime. Defaults to 12 hours. |
+   | `AUTH_COOKIE_SECURE` | Optional cookie secure override. Defaults to `true` for HTTPS origins. |
 
 2. Build and start the stack:
 
@@ -61,6 +71,18 @@ This folder hosts a lightweight HTTP + WebSocket service that coordinates YouTub
 | `POST` | `/save_history` | Acknowledge history sync events from the extension. |
 
 Responses always include CORS headers so the extension can call the endpoints directly from the browser environment.
+
+## Authentik login
+
+If the authentik variables above are configured, the root page (`/`) becomes a login landing page and only authenticated users can access the history dashboard and `/history/*` browser routes. The Chrome extension compatibility endpoints (`/download`, `/stop_download`, `/restart_download`, `/downloads`, `/save_history`) stay unchanged so the existing extension flow still works.
+
+For a standard authentik OAuth2/OpenID Connect provider, set the callback URL in authentik to:
+
+```text
+https://your-public-origin.example.com/auth/callback
+```
+
+The history page will use a separate authenticated WebSocket path at `/history/ws`, while the original WebSocket path remains available for the extension.
 
 ## Notes
 

--- a/web-version/backend/src/auth.ts
+++ b/web-version/backend/src/auth.ts
@@ -54,6 +54,8 @@ interface UserInfoResponse {
     nickname?: string;
 }
 
+const OIDC_REQUEST_TIMEOUT_MS = 10_000;
+
 interface CookieOptions {
     httpOnly?: boolean;
     path?: string;
@@ -190,6 +192,14 @@ function redirectResponse(
 function textResponse(res: ServerResponse, statusCode: number, message: string): void {
     res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
     res.end(message);
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T | null> {
+    try {
+        return (await response.json()) as T;
+    } catch (_error) {
+        return null;
+    }
 }
 
 function createRandomToken(bytes = 32): string {
@@ -418,7 +428,9 @@ export class AuthManager {
         }
 
         if (!this.discoveryPromise) {
-            this.discoveryPromise = fetch(config.discoveryUrl)
+            this.discoveryPromise = fetch(config.discoveryUrl, {
+                signal: AbortSignal.timeout(OIDC_REQUEST_TIMEOUT_MS)
+            })
                 .then(async (response) => {
                     if (!response.ok) {
                         throw new Error(`Failed to load Authentik discovery document (${response.status}).`);
@@ -434,6 +446,10 @@ export class AuthManager {
                         throw new Error('Authentik discovery document is missing required OIDC endpoints.');
                     }
                     return document;
+                })
+                .catch((errorValue) => {
+                    this.discoveryPromise = null;
+                    throw errorValue;
                 });
         }
 
@@ -464,14 +480,15 @@ export class AuthManager {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded'
             },
-            body: payload.toString()
+            body: payload.toString(),
+            signal: AbortSignal.timeout(OIDC_REQUEST_TIMEOUT_MS)
         });
 
-        const tokenResponse = (await response.json()) as TokenResponse;
-        if (!response.ok || typeof tokenResponse.access_token !== 'string') {
+        const tokenResponse = await parseJsonResponse<TokenResponse>(response);
+        if (!response.ok || typeof tokenResponse?.access_token !== 'string') {
             const errorDescription =
-                tokenResponse.error_description ||
-                tokenResponse.error ||
+                tokenResponse?.error_description ||
+                tokenResponse?.error ||
                 `OIDC token exchange failed with status ${response.status}.`;
             throw new Error(errorDescription);
         }
@@ -483,14 +500,18 @@ export class AuthManager {
         const response = await fetch(discovery.userinfo_endpoint, {
             headers: {
                 Authorization: `Bearer ${accessToken}`
-            }
+            },
+            signal: AbortSignal.timeout(OIDC_REQUEST_TIMEOUT_MS)
         });
 
         if (!response.ok) {
             throw new Error(`Failed to load user profile from Authentik (${response.status}).`);
         }
 
-        const userInfo = (await response.json()) as UserInfoResponse;
+        const userInfo = await parseJsonResponse<UserInfoResponse>(response);
+        if (!userInfo) {
+            throw new Error('Failed to parse Authentik user profile response.');
+        }
         const normalised = normaliseUserInfo(userInfo);
         if (!normalised) {
             throw new Error('Authentik user profile is missing required identity fields.');

--- a/web-version/backend/src/auth.ts
+++ b/web-version/backend/src/auth.ts
@@ -1,0 +1,501 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+export interface AuthConfig {
+    discoveryUrl: string;
+    clientId: string;
+    clientSecret: string;
+    publicOrigin: string;
+    scopes: string[];
+    sessionSecret: string;
+    sessionCookieName: string;
+    flowCookieName: string;
+    sessionTtlSeconds: number;
+    cookieSecure: boolean;
+}
+
+export interface AuthenticatedViewer {
+    displayName: string;
+    email?: string | null;
+}
+
+interface DiscoveryDocument {
+    authorization_endpoint: string;
+    token_endpoint: string;
+    userinfo_endpoint: string;
+    end_session_endpoint?: string;
+}
+
+interface FlowStatePayload {
+    state: string;
+    codeVerifier: string;
+    expiresAt: number;
+}
+
+interface SessionPayload {
+    sub: string;
+    displayName: string;
+    email?: string | null;
+    expiresAt: number;
+}
+
+interface TokenResponse {
+    access_token?: string;
+    token_type?: string;
+    error?: string;
+    error_description?: string;
+}
+
+interface UserInfoResponse {
+    sub?: string;
+    name?: string;
+    email?: string;
+    preferred_username?: string;
+    nickname?: string;
+}
+
+interface CookieOptions {
+    httpOnly?: boolean;
+    path?: string;
+    sameSite?: 'Lax' | 'Strict' | 'None';
+    secure?: boolean;
+    maxAge?: number;
+    expires?: Date;
+}
+
+function parseCookieHeader(headerValue: string | undefined): Record<string, string> {
+    if (!headerValue) {
+        return {};
+    }
+
+    const pairs = headerValue.split(';');
+    const cookies: Record<string, string> = {};
+    for (const pair of pairs) {
+        const separatorIndex = pair.indexOf('=');
+        if (separatorIndex <= 0) {
+            continue;
+        }
+
+        const rawName = pair.slice(0, separatorIndex).trim();
+        const rawValue = pair.slice(separatorIndex + 1).trim();
+        if (!rawName) {
+            continue;
+        }
+
+        try {
+            cookies[rawName] = decodeURIComponent(rawValue);
+        } catch (_error) {
+            cookies[rawName] = rawValue;
+        }
+    }
+
+    return cookies;
+}
+
+function serialiseCookie(name: string, value: string, options: CookieOptions): string {
+    const segments = [`${name}=${encodeURIComponent(value)}`];
+
+    segments.push(`Path=${options.path ?? '/'}`);
+    if (typeof options.maxAge === 'number') {
+        segments.push(`Max-Age=${Math.max(0, Math.floor(options.maxAge))}`);
+    }
+    if (options.expires) {
+        segments.push(`Expires=${options.expires.toUTCString()}`);
+    }
+    if (options.httpOnly) {
+        segments.push('HttpOnly');
+    }
+    if (options.sameSite) {
+        segments.push(`SameSite=${options.sameSite}`);
+    }
+    if (options.secure) {
+        segments.push('Secure');
+    }
+
+    return segments.join('; ');
+}
+
+function toBase64Url(value: string): string {
+    return Buffer.from(value, 'utf-8').toString('base64url');
+}
+
+function fromBase64Url(value: string): string | null {
+    try {
+        return Buffer.from(value, 'base64url').toString('utf-8');
+    } catch (_error) {
+        return null;
+    }
+}
+
+function createSignature(value: string, secret: string): string {
+    return createHmac('sha256', secret).update(value).digest('base64url');
+}
+
+function safeEqual(left: string, right: string): boolean {
+    const leftBuffer = Buffer.from(left, 'utf-8');
+    const rightBuffer = Buffer.from(right, 'utf-8');
+
+    if (leftBuffer.length !== rightBuffer.length) {
+        return false;
+    }
+
+    return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function encodeSignedPayload<T extends object>(payload: T, secret: string): string {
+    const encoded = toBase64Url(JSON.stringify(payload));
+    const signature = createSignature(encoded, secret);
+    return `${encoded}.${signature}`;
+}
+
+function decodeSignedPayload<T extends object>(cookieValue: string | undefined, secret: string): T | null {
+    if (!cookieValue) {
+        return null;
+    }
+
+    const [encoded, signature] = cookieValue.split('.');
+    if (!encoded || !signature) {
+        return null;
+    }
+
+    const expectedSignature = createSignature(encoded, secret);
+    if (!safeEqual(signature, expectedSignature)) {
+        return null;
+    }
+
+    const decoded = fromBase64Url(encoded);
+    if (!decoded) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(decoded) as T;
+    } catch (_error) {
+        return null;
+    }
+}
+
+function redirectResponse(
+    res: ServerResponse,
+    location: string,
+    headers: Record<string, string | string[]> = {}
+): void {
+    res.writeHead(302, {
+        Location: location,
+        ...headers
+    });
+    res.end();
+}
+
+function textResponse(res: ServerResponse, statusCode: number, message: string): void {
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(message);
+}
+
+function createRandomToken(bytes = 32): string {
+    return randomBytes(bytes).toString('base64url');
+}
+
+function createCodeChallenge(codeVerifier: string): string {
+    return createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+function normaliseUserInfo(userInfo: UserInfoResponse): SessionPayload | null {
+    if (typeof userInfo.sub !== 'string' || userInfo.sub.length === 0) {
+        return null;
+    }
+
+    const displayName = [
+        userInfo.name,
+        userInfo.preferred_username,
+        userInfo.nickname,
+        userInfo.email,
+        userInfo.sub
+    ].find((value) => typeof value === 'string' && value.trim().length > 0);
+
+    if (!displayName) {
+        return null;
+    }
+
+    return {
+        sub: userInfo.sub,
+        displayName,
+        email: typeof userInfo.email === 'string' ? userInfo.email : null,
+        expiresAt: 0
+    };
+}
+
+export class AuthManager {
+    private readonly config: AuthConfig | null;
+    private discoveryPromise: Promise<DiscoveryDocument> | null = null;
+
+    constructor(config: AuthConfig | null) {
+        this.config = config;
+    }
+
+    isEnabled(): boolean {
+        return this.config !== null;
+    }
+
+    isAuthenticated(req: IncomingMessage): boolean {
+        return this.getViewer(req) !== null;
+    }
+
+    getViewer(req: IncomingMessage): AuthenticatedViewer | null {
+        const config = this.config;
+        if (!config) {
+            return null;
+        }
+
+        const cookies = parseCookieHeader(req.headers.cookie);
+        const session = decodeSignedPayload<SessionPayload>(cookies[config.sessionCookieName], config.sessionSecret);
+        if (!session) {
+            return null;
+        }
+
+        if (session.expiresAt <= Date.now()) {
+            return null;
+        }
+
+        return {
+            displayName: session.displayName,
+            email: session.email ?? null
+        };
+    }
+
+    sendUnauthorized(res: ServerResponse): void {
+        textResponse(res, 401, 'Authentication required.');
+    }
+
+    async handleLogin(req: IncomingMessage, res: ServerResponse): Promise<void> {
+        const config = this.config;
+        if (!config) {
+            textResponse(res, 404, 'Authentication is not configured.');
+            return;
+        }
+
+        if (this.isAuthenticated(req)) {
+            redirectResponse(res, '/');
+            return;
+        }
+
+        const discovery = await this.getDiscovery();
+        const state = createRandomToken(24);
+        const codeVerifier = createRandomToken(48);
+        const flowState: FlowStatePayload = {
+            state,
+            codeVerifier,
+            expiresAt: Date.now() + 10 * 60 * 1000
+        };
+
+        const loginUrl = new URL(discovery.authorization_endpoint);
+        loginUrl.searchParams.set('response_type', 'code');
+        loginUrl.searchParams.set('client_id', config.clientId);
+        loginUrl.searchParams.set('redirect_uri', this.getCallbackUrl());
+        loginUrl.searchParams.set('scope', config.scopes.join(' '));
+        loginUrl.searchParams.set('state', state);
+        loginUrl.searchParams.set('code_challenge_method', 'S256');
+        loginUrl.searchParams.set('code_challenge', createCodeChallenge(codeVerifier));
+
+        const flowCookie = serialiseCookie(
+            config.flowCookieName,
+            encodeSignedPayload(flowState, config.sessionSecret),
+            {
+                httpOnly: true,
+                sameSite: 'Lax',
+                secure: config.cookieSecure,
+                path: '/',
+                maxAge: 10 * 60
+            }
+        );
+
+        redirectResponse(res, loginUrl.toString(), { 'Set-Cookie': flowCookie });
+    }
+
+    async handleCallback(req: IncomingMessage, res: ServerResponse, currentUrl: URL): Promise<void> {
+        const config = this.config;
+        if (!config) {
+            textResponse(res, 404, 'Authentication is not configured.');
+            return;
+        }
+
+        const error = currentUrl.searchParams.get('error');
+        if (error) {
+            this.redirectToLoginError(res, currentUrl.searchParams.get('error_description') ?? error);
+            return;
+        }
+
+        const code = currentUrl.searchParams.get('code');
+        const state = currentUrl.searchParams.get('state');
+        if (!code || !state) {
+            this.redirectToLoginError(res, 'OIDC callback is missing required parameters.');
+            return;
+        }
+
+        const cookies = parseCookieHeader(req.headers.cookie);
+        const flowState = decodeSignedPayload<FlowStatePayload>(cookies[config.flowCookieName], config.sessionSecret);
+        if (!flowState || flowState.expiresAt <= Date.now() || flowState.state !== state) {
+            this.redirectToLoginError(res, 'The login session expired. Please try again.');
+            return;
+        }
+
+        try {
+            const discovery = await this.getDiscovery();
+            const tokenResponse = await this.exchangeCode(discovery, code, flowState.codeVerifier);
+            const sessionBase = await this.fetchUserInfo(discovery, tokenResponse.access_token);
+            const sessionPayload: SessionPayload = {
+                ...sessionBase,
+                expiresAt: Date.now() + config.sessionTtlSeconds * 1000
+            };
+
+            const clearFlowCookie = this.clearCookie(config.flowCookieName);
+            const sessionCookie = serialiseCookie(
+                config.sessionCookieName,
+                encodeSignedPayload(sessionPayload, config.sessionSecret),
+                {
+                    httpOnly: true,
+                    sameSite: 'Lax',
+                    secure: config.cookieSecure,
+                    path: '/',
+                    maxAge: config.sessionTtlSeconds
+                }
+            );
+
+            redirectResponse(res, '/', {
+                'Set-Cookie': [clearFlowCookie, sessionCookie]
+            });
+        } catch (errorValue) {
+            const message = errorValue instanceof Error ? errorValue.message : 'Failed to complete login.';
+            this.redirectToLoginError(res, message);
+        }
+    }
+
+    handleLogout(res: ServerResponse): void {
+        const config = this.config;
+        if (!config) {
+            redirectResponse(res, '/');
+            return;
+        }
+
+        redirectResponse(res, '/', {
+            'Set-Cookie': [
+                this.clearCookie(config.sessionCookieName),
+                this.clearCookie(config.flowCookieName)
+            ]
+        });
+    }
+
+    private clearCookie(name: string): string {
+        return serialiseCookie(name, '', {
+            httpOnly: true,
+            sameSite: 'Lax',
+            secure: this.config?.cookieSecure ?? false,
+            path: '/',
+            maxAge: 0,
+            expires: new Date(0)
+        });
+    }
+
+    private getCallbackUrl(): string {
+        const config = this.config;
+        if (!config) {
+            throw new Error('Authentication is not configured.');
+        }
+
+        return new URL('/auth/callback', config.publicOrigin).toString();
+    }
+
+    private redirectToLoginError(res: ServerResponse, message: string): void {
+        const target = new URL('/', this.config?.publicOrigin ?? 'http://localhost');
+        target.searchParams.set('auth_error', message);
+        redirectResponse(res, `${target.pathname}${target.search}`);
+    }
+
+    private async getDiscovery(): Promise<DiscoveryDocument> {
+        const config = this.config;
+        if (!config) {
+            throw new Error('Authentication is not configured.');
+        }
+
+        if (!this.discoveryPromise) {
+            this.discoveryPromise = fetch(config.discoveryUrl)
+                .then(async (response) => {
+                    if (!response.ok) {
+                        throw new Error(`Failed to load Authentik discovery document (${response.status}).`);
+                    }
+                    return (await response.json()) as DiscoveryDocument;
+                })
+                .then((document) => {
+                    if (
+                        typeof document.authorization_endpoint !== 'string' ||
+                        typeof document.token_endpoint !== 'string' ||
+                        typeof document.userinfo_endpoint !== 'string'
+                    ) {
+                        throw new Error('Authentik discovery document is missing required OIDC endpoints.');
+                    }
+                    return document;
+                });
+        }
+
+        return this.discoveryPromise;
+    }
+
+    private async exchangeCode(
+        discovery: DiscoveryDocument,
+        code: string,
+        codeVerifier: string
+    ): Promise<{ access_token: string }> {
+        const config = this.config;
+        if (!config) {
+            throw new Error('Authentication is not configured.');
+        }
+
+        const payload = new URLSearchParams({
+            grant_type: 'authorization_code',
+            client_id: config.clientId,
+            client_secret: config.clientSecret,
+            redirect_uri: this.getCallbackUrl(),
+            code,
+            code_verifier: codeVerifier
+        });
+
+        const response = await fetch(discovery.token_endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: payload.toString()
+        });
+
+        const tokenResponse = (await response.json()) as TokenResponse;
+        if (!response.ok || typeof tokenResponse.access_token !== 'string') {
+            const errorDescription =
+                tokenResponse.error_description ||
+                tokenResponse.error ||
+                `OIDC token exchange failed with status ${response.status}.`;
+            throw new Error(errorDescription);
+        }
+
+        return { access_token: tokenResponse.access_token };
+    }
+
+    private async fetchUserInfo(discovery: DiscoveryDocument, accessToken: string): Promise<SessionPayload> {
+        const response = await fetch(discovery.userinfo_endpoint, {
+            headers: {
+                Authorization: `Bearer ${accessToken}`
+            }
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to load user profile from Authentik (${response.status}).`);
+        }
+
+        const userInfo = (await response.json()) as UserInfoResponse;
+        const normalised = normaliseUserInfo(userInfo);
+        if (!normalised) {
+            throw new Error('Authentik user profile is missing required identity fields.');
+        }
+
+        return normalised;
+    }
+}

--- a/web-version/backend/src/config.ts
+++ b/web-version/backend/src/config.ts
@@ -39,9 +39,24 @@ export interface ServerConfig {
   maxConcurrent: number;
   httpPort: number;
   wsPath: string;
+  historyWsPath: string;
   qualityLimit: number | null;
   checkFormatList: boolean;
+  auth: AuthConfig | null;
   runner: RunnerConfig;
+}
+
+export interface AuthConfig {
+  discoveryUrl: string;
+  clientId: string;
+  clientSecret: string;
+  publicOrigin: string;
+  scopes: string[];
+  sessionSecret: string;
+  sessionCookieName: string;
+  flowCookieName: string;
+  sessionTtlSeconds: number;
+  cookieSecure: boolean;
 }
 
 function parseInteger(value: string | undefined, fallback: number): number {
@@ -104,6 +119,95 @@ function buildRunner(downloadDir: string): RunnerConfig {
   };
 }
 
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!value) {
+    return fallback;
+  }
+
+  const normalised = value.trim().toLowerCase();
+  if (normalised === 'true') {
+    return true;
+  }
+  if (normalised === 'false') {
+    return false;
+  }
+
+  return fallback;
+}
+
+function buildDiscoveryUrl(baseUrl: string, applicationSlug: string): string {
+  const base = new URL(baseUrl);
+  base.pathname = `/application/o/${applicationSlug}/.well-known/openid-configuration`;
+  base.search = '';
+  base.hash = '';
+  return base.toString();
+}
+
+function loadAuthConfig(): AuthConfig | null {
+  const explicitDiscoveryUrl = process.env.AUTHENTIK_DISCOVERY_URL?.trim();
+  const baseUrl = process.env.AUTHENTIK_BASE_URL?.trim();
+  const applicationSlug = process.env.AUTHENTIK_APPLICATION_SLUG?.trim();
+  const clientId = process.env.AUTHENTIK_CLIENT_ID?.trim();
+  const clientSecret = process.env.AUTHENTIK_CLIENT_SECRET?.trim();
+  const publicOrigin = process.env.AUTHENTIK_PUBLIC_ORIGIN?.trim();
+  const sessionSecret = (process.env.AUTH_SESSION_SECRET || process.env.AUTHENTIK_CLIENT_SECRET || '').trim();
+
+  const discoveryUrl =
+    explicitDiscoveryUrl ||
+    (baseUrl && applicationSlug ? buildDiscoveryUrl(baseUrl, applicationSlug) : '');
+
+  const hasAnyAuthSetting = [
+    explicitDiscoveryUrl,
+    baseUrl,
+    applicationSlug,
+    clientId,
+    clientSecret,
+    publicOrigin,
+    process.env.AUTH_SESSION_SECRET
+  ].some((value) => typeof value === 'string' && value.trim().length > 0);
+
+  if (!hasAnyAuthSetting) {
+    return null;
+  }
+
+  const missing: string[] = [];
+  if (!discoveryUrl) missing.push('AUTHENTIK_DISCOVERY_URL or AUTHENTIK_BASE_URL + AUTHENTIK_APPLICATION_SLUG');
+  if (!clientId) missing.push('AUTHENTIK_CLIENT_ID');
+  if (!clientSecret) missing.push('AUTHENTIK_CLIENT_SECRET');
+  if (!publicOrigin) missing.push('AUTHENTIK_PUBLIC_ORIGIN');
+  if (!sessionSecret) missing.push('AUTH_SESSION_SECRET');
+
+  if (missing.length > 0) {
+    throw new Error(`Missing authentik configuration: ${missing.join(', ')}`);
+  }
+
+  const resolvedDiscoveryUrl: string = discoveryUrl ?? '';
+  const resolvedClientId: string = clientId ?? '';
+  const resolvedClientSecret: string = clientSecret ?? '';
+  const resolvedPublicOrigin: string = publicOrigin ?? '';
+  const resolvedSessionSecret: string = sessionSecret ?? '';
+  const publicUrl = new URL(resolvedPublicOrigin);
+  const sessionTtlSeconds = parseInteger(process.env.AUTH_SESSION_TTL_SECONDS, 12 * 60 * 60);
+  const rawScopes = process.env.AUTHENTIK_SCOPES || 'openid profile email';
+  const scopes = rawScopes
+    .split(/[\s,]+/u)
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+
+  return {
+    discoveryUrl: resolvedDiscoveryUrl,
+    clientId: resolvedClientId,
+    clientSecret: resolvedClientSecret,
+    publicOrigin: publicUrl.toString(),
+    scopes: scopes.length > 0 ? scopes : ['openid', 'profile', 'email'],
+    sessionSecret: resolvedSessionSecret,
+    sessionCookieName: process.env.AUTH_SESSION_COOKIE_NAME || 'ducktracker_auth',
+    flowCookieName: process.env.AUTH_FLOW_COOKIE_NAME || 'ducktracker_auth_flow',
+    sessionTtlSeconds,
+    cookieSecure: parseBoolean(process.env.AUTH_COOKIE_SECURE, publicUrl.protocol === 'https:')
+  };
+}
+
 export function loadConfig(): ServerConfig {
   const rawDownloadDir = process.env.DOWNLOAD_DIR || DEFAULT_DOWNLOAD_DIR;
   const downloadDir = path.resolve(rawDownloadDir);
@@ -114,12 +218,14 @@ export function loadConfig(): ServerConfig {
   const maxConcurrent = parseInteger(process.env.MAX_CONCURRENT_DOWNLOADS, 2);
   const httpPort = parseInteger(process.env.PORT || process.env.HTTP_PORT, 8080);
   const wsPath = process.env.WS_PATH || '/';
+  const historyWsPath = process.env.HISTORY_WS_PATH || '/history/ws';
 
   const qualityLimit = normaliseQuality(process.env.DOWNLOAD_QUALITY);
 
   const format = process.env.DOWNLOAD_FORMAT || buildFormat(DEFAULT_FORMAT, qualityLimit);
   const template = process.env.OUTPUT_TEMPLATE || DEFAULT_TEMPLATE;
   const checkFormatList = process.env.CHECK_FORMAT_LIST?.toLowerCase() === "true" || false;
+  const auth = loadAuthConfig();
 
 
   const ensureDir = process.env.SKIP_DIR_CREATION !== 'true';
@@ -136,8 +242,10 @@ export function loadConfig(): ServerConfig {
     maxConcurrent,
     httpPort,
     wsPath,
+    historyWsPath,
     qualityLimit,
     checkFormatList,
+    auth,
     runner: buildRunner(downloadDir)
   };
 }

--- a/web-version/backend/src/history-page.ts
+++ b/web-version/backend/src/history-page.ts
@@ -1,4 +1,5 @@
 import type { DownloadRecordRow } from './database.js';
+import type { AuthenticatedViewer } from './auth.js';
 import type { HistoryPageViewProps } from '@shared/history-page';
 
 export interface RenderHistoryPageOptions {
@@ -11,6 +12,12 @@ export interface RenderHistoryPageOptions {
     searchTerm?: string;
     wsPath?: string;
     checkFormatList: boolean;
+    viewer?: AuthenticatedViewer | null;
+}
+
+export interface RenderLoginPageOptions {
+    loginPath: string;
+    errorMessage?: string;
 }
 
 function normaliseWsPath(path?: string): string {
@@ -29,7 +36,8 @@ function buildHistoryPageProps({
     selectedStatuses,
     wsPath,
     checkFormatList,
-    statusCounts
+    statusCounts,
+    viewer
 }: RenderHistoryPageOptions): HistoryPageViewProps {
     const safePageSize = Math.max(1, pageSize);
     const totalPages = Math.max(1, Math.ceil(total / safePageSize));
@@ -48,7 +56,8 @@ function buildHistoryPageProps({
         wsPath: normaliseWsPath(wsPath),
         checkFormatList,
         selectedStatuses,
-        statusCounts
+        statusCounts,
+        viewer: viewer ?? null
     };
 }
 
@@ -59,6 +68,15 @@ function escapeHtmlAttribute(value: string): string {
         .replace(/'/g, '&#39;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;');
+}
+
+function escapeHtmlText(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 function serialisePropsForScript(value: unknown): string {
@@ -87,6 +105,37 @@ export function renderHistoryPageToHtml(options: RenderHistoryPageOptions): stri
         '</body>',
         '</html>'
     ].join('');
+}
+
+export function renderLoginPageToHtml({ loginPath, errorMessage }: RenderLoginPageOptions): string {
+    const safeLoginPath = escapeHtmlAttribute(loginPath);
+    const safeError = errorMessage ? escapeHtmlText(errorMessage) : '';
+    const errorMarkup = safeError.length > 0
+        ? `        <p class="auth-card__error" role="alert">${safeError}</p>`
+        : '';
+
+    return [
+        '<!DOCTYPE html>',
+        '<html lang="ko">',
+        '<head>',
+        '    <meta charSet="UTF-8" />',
+        '    <meta name="viewport" content="width=device-width, initial-scale=1.0" />',
+        '    <title>DuckTracker 로그인</title>',
+        '    <link rel="stylesheet" href="/history/assets/history-page.css" />',
+        '</head>',
+        '<body>',
+        '    <main class="auth-shell">',
+        '        <section class="auth-card">',
+        '            <span class="auth-card__eyebrow">Protected workspace</span>',
+        '            <h1 class="auth-card__title">DuckTracker에 로그인하세요</h1>',
+        '            <p class="auth-card__description">authentik 인증을 통과한 사용자만 다운로드 대시보드에 접근할 수 있습니다.</p>',
+        errorMarkup,
+        `            <a class="button button--primary auth-card__button" href="${safeLoginPath}">authentik으로 로그인</a>`,
+        '        </section>',
+        '    </main>',
+        '</body>',
+        '</html>'
+    ].join('\n');
 }
 
 export type { HistoryPageViewProps } from '@shared/history-page';

--- a/web-version/backend/src/http/handlers/history.ts
+++ b/web-version/backend/src/http/handlers/history.ts
@@ -22,6 +22,7 @@ import {
     resolveHistoryFileOrThrow,
     resolveWithinDownloadDir
 } from '../../history/files.js';
+import type { AuthenticatedViewer } from '../../auth.js';
 
 interface HistoryHandlerDeps {
     config: ServerConfig;
@@ -93,7 +94,12 @@ type HistoryQuery = Record<string, string | string[] | undefined>;
 export function createHistoryHandlers({ config, downloadManager }: HistoryHandlerDeps) {
     const fileContext = { config, downloadManager } as const;
 
-    function handleHistoryPage(_req: IncomingMessage, res: ServerResponse, query: HistoryQuery): void {
+    function handleHistoryPage(
+        _req: IncomingMessage,
+        res: ServerResponse,
+        query: HistoryQuery,
+        viewer?: AuthenticatedViewer | null
+    ): void {
         const searchTerm = typeof query.search === 'string' ? query.search.trim() : '';
         let page = parseInteger(query.page, 1);
         let pageSize = parseInteger(query.pageSize, 20);
@@ -150,8 +156,9 @@ export function createHistoryHandlers({ config, downloadManager }: HistoryHandle
             selectedStatuses: statusFilter,
             statusCounts: result.statusCounts,
             searchTerm,
-            wsPath: config.wsPath,
-            checkFormatList: config.checkFormatList
+            wsPath: config.auth ? config.historyWsPath : config.wsPath,
+            checkFormatList: config.checkFormatList,
+            viewer
         });
 
         htmlResponse(res, 200, html);

--- a/web-version/backend/src/http/router.ts
+++ b/web-version/backend/src/http/router.ts
@@ -1,8 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import * as url from 'node:url';
+import { AuthManager } from '../auth.js';
 import type { ServerConfig } from '../config.js';
 import type { DownloadManager } from '../download-manager.js';
 import { jsonResponse, sendOptionsResponse } from './responses.js';
+import { createAuthRoutes } from './routes/auth.js';
 import { createHistoryRoutes } from './routes/history/index.js';
 import { createDownloadRoutes } from './routes/downloads.js';
 import { createAssetRoutes } from './routes/assets/index.js';
@@ -13,9 +15,11 @@ export interface RouterDependencies {
 }
 
 export function createRequestHandler(deps: RouterDependencies) {
+    const authManager = new AuthManager(deps.config.auth);
     const assetRoutes = createAssetRoutes();
-    const historyRoutes = createHistoryRoutes(deps);
-    const downloadRoutes = createDownloadRoutes(deps);
+    const authRoutes = createAuthRoutes(authManager);
+    const historyRoutes = createHistoryRoutes({ ...deps, authManager });
+    const downloadRoutes = createDownloadRoutes({ ...deps, authManager });
 
     return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
         const parsedUrl = url.parse(req.url || '/', true);
@@ -27,6 +31,10 @@ export function createRequestHandler(deps: RouterDependencies) {
         }
 
         if (assetRoutes(req, res, parsedUrl)) {
+            return;
+        }
+
+        if (await authRoutes(req, res, parsedUrl)) {
             return;
         }
 

--- a/web-version/backend/src/http/routes/auth.ts
+++ b/web-version/backend/src/http/routes/auth.ts
@@ -1,0 +1,28 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { UrlWithParsedQuery } from 'node:url';
+import { AuthManager } from '../../auth.js';
+
+export function createAuthRoutes(authManager: AuthManager) {
+    return async (req: IncomingMessage, res: ServerResponse, parsedUrl: UrlWithParsedQuery): Promise<boolean> => {
+        const pathname = parsedUrl.pathname ?? '/';
+        const method = req.method ?? 'GET';
+
+        if (method === 'GET' && pathname === '/auth/login') {
+            await authManager.handleLogin(req, res);
+            return true;
+        }
+
+        if (method === 'GET' && pathname === '/auth/callback') {
+            const currentUrl = new URL(req.url ?? '/auth/callback', 'http://localhost');
+            await authManager.handleCallback(req, res, currentUrl);
+            return true;
+        }
+
+        if (method === 'GET' && pathname === '/auth/logout') {
+            authManager.handleLogout(res);
+            return true;
+        }
+
+        return false;
+    };
+}

--- a/web-version/backend/src/http/routes/auth.ts
+++ b/web-version/backend/src/http/routes/auth.ts
@@ -2,19 +2,35 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { UrlWithParsedQuery } from 'node:url';
 import { AuthManager } from '../../auth.js';
 
+function redirectToLoginError(res: ServerResponse, message: string): void {
+    const search = new URLSearchParams({ auth_error: message });
+    res.writeHead(302, { Location: `/?${search.toString()}` });
+    res.end();
+}
+
 export function createAuthRoutes(authManager: AuthManager) {
     return async (req: IncomingMessage, res: ServerResponse, parsedUrl: UrlWithParsedQuery): Promise<boolean> => {
         const pathname = parsedUrl.pathname ?? '/';
         const method = req.method ?? 'GET';
 
         if (method === 'GET' && pathname === '/auth/login') {
-            await authManager.handleLogin(req, res);
+            try {
+                await authManager.handleLogin(req, res);
+            } catch (errorValue) {
+                const message = errorValue instanceof Error ? errorValue.message : 'Failed to start login.';
+                redirectToLoginError(res, message);
+            }
             return true;
         }
 
         if (method === 'GET' && pathname === '/auth/callback') {
             const currentUrl = new URL(req.url ?? '/auth/callback', 'http://localhost');
-            await authManager.handleCallback(req, res, currentUrl);
+            try {
+                await authManager.handleCallback(req, res, currentUrl);
+            } catch (errorValue) {
+                const message = errorValue instanceof Error ? errorValue.message : 'Failed to complete login.';
+                redirectToLoginError(res, message);
+            }
             return true;
         }
 

--- a/web-version/backend/src/http/routes/downloads.ts
+++ b/web-version/backend/src/http/routes/downloads.ts
@@ -1,16 +1,28 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { UrlWithParsedQuery } from 'node:url';
 import { createDownloadHandlers } from '../handlers/downloads.js';
+import { AuthManager } from '../../auth.js';
 import type { ServerConfig } from '../../config.js';
 import type { DownloadManager } from '../../download-manager.js';
 
 interface DownloadRouteDeps {
     config: ServerConfig;
     downloadManager: DownloadManager;
+    authManager: AuthManager;
 }
 
 export function createDownloadRoutes(deps: DownloadRouteDeps) {
     const handlers = createDownloadHandlers(deps);
+    const { authManager } = deps;
+
+    function ensureAuthenticated(req: IncomingMessage, res: ServerResponse): boolean {
+        if (!authManager.isEnabled() || authManager.isAuthenticated(req)) {
+            return true;
+        }
+
+        authManager.sendUnauthorized(res);
+        return false;
+    }
 
     return async (req: IncomingMessage, res: ServerResponse, parsedUrl: UrlWithParsedQuery): Promise<boolean> => {
         const pathname = parsedUrl.pathname ?? '/';
@@ -31,7 +43,23 @@ export function createDownloadRoutes(deps: DownloadRouteDeps) {
             return true;
         }
 
+        if (method === 'POST' && pathname === '/history/stop-download') {
+            if (!ensureAuthenticated(req, res)) {
+                return true;
+            }
+            await handlers.handleStopDownload(req, res);
+            return true;
+        }
+
         if (method === 'POST' && pathname === '/restart_download') {
+            await handlers.handleRestartDownload(req, res);
+            return true;
+        }
+
+        if (method === 'POST' && pathname === '/history/restart-download') {
+            if (!ensureAuthenticated(req, res)) {
+                return true;
+            }
             await handlers.handleRestartDownload(req, res);
             return true;
         }

--- a/web-version/backend/src/http/routes/history/index.ts
+++ b/web-version/backend/src/http/routes/history/index.ts
@@ -1,27 +1,49 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { UrlWithParsedQuery } from 'node:url';
+import { AuthManager } from '../../../auth.js';
 import { createHistoryHandlers } from '../../handlers/history.js';
 import type { ServerConfig } from '../../../config.js';
 import type { DownloadManager } from '../../../download-manager.js';
+import { htmlResponse } from '../../responses.js';
+import { renderLoginPageToHtml } from '../../../history-page.js';
 
 interface HistoryRouteDeps {
     config: ServerConfig;
     downloadManager: DownloadManager;
+    authManager: AuthManager;
 }
 
 export function createHistoryRoutes(deps: HistoryRouteDeps) {
     const handlers = createHistoryHandlers(deps);
+    const { authManager } = deps;
 
     return async (req: IncomingMessage, res: ServerResponse, parsedUrl: UrlWithParsedQuery): Promise<boolean> => {
         const pathname = parsedUrl.pathname ?? '/';
         const method = req.method ?? 'GET';
+        const isAuthenticated = authManager.isAuthenticated(req);
 
         if (method === 'GET' && pathname === '/') {
-            handlers.handleHistoryPage(req, res, parsedUrl.query || {});
+            if (authManager.isEnabled() && !isAuthenticated) {
+                const authError = typeof parsedUrl.query?.auth_error === 'string'
+                    ? parsedUrl.query.auth_error
+                    : undefined;
+                const html = renderLoginPageToHtml({
+                    loginPath: '/auth/login',
+                    errorMessage: authError
+                });
+                htmlResponse(res, 200, html);
+                return true;
+            }
+
+            handlers.handleHistoryPage(req, res, parsedUrl.query || {}, authManager.getViewer(req));
             return true;
         }
 
         if (method === 'POST' && pathname === '/history/request-download') {
+            if (authManager.isEnabled() && !isAuthenticated) {
+                authManager.sendUnauthorized(res);
+                return true;
+            }
             await handlers.handleHistoryDownloadRequest(req, res);
             return true;
         }
@@ -44,10 +66,18 @@ export function createHistoryRoutes(deps: HistoryRouteDeps) {
 
         if (method === 'DELETE') {
             if (segments.length === 3 && segments[2] === 'file') {
+                if (authManager.isEnabled() && !isAuthenticated) {
+                    authManager.sendUnauthorized(res);
+                    return true;
+                }
                 await handlers.handleHistoryFileDelete(req, res, urlId);
                 return true;
             }
             if (segments.length === 2) {
+                if (authManager.isEnabled() && !isAuthenticated) {
+                    authManager.sendUnauthorized(res);
+                    return true;
+                }
                 await handlers.handleHistoryDelete(req, res, urlId);
                 return true;
             }
@@ -57,10 +87,18 @@ export function createHistoryRoutes(deps: HistoryRouteDeps) {
             if (segments.length === 3) {
                 const action = segments[2];
                 if (action === 'file') {
+                    if (authManager.isEnabled() && !isAuthenticated) {
+                        authManager.sendUnauthorized(res);
+                        return true;
+                    }
                     await handlers.handleHistoryFileDownload(req, res, urlId);
                     return true;
                 }
                 if (action === 'stream') {
+                    if (authManager.isEnabled() && !isAuthenticated) {
+                        authManager.sendUnauthorized(res);
+                        return true;
+                    }
                     await handlers.handleHistoryFileStream(req, res, urlId);
                     return true;
                 }

--- a/web-version/backend/src/index.ts
+++ b/web-version/backend/src/index.ts
@@ -1,4 +1,5 @@
 import * as http from 'node:http';
+import { AuthManager } from './auth.js';
 import { loadConfig, type ServerConfig } from './config.js';
 import { DownloadManager } from './download-manager.js';
 import { createWebSocketServer, handleUpgrade, WebSocket } from './websocket-server.js';
@@ -10,6 +11,7 @@ const config: ServerConfig = loadConfig();
 initDatabase(config.dbPath);
 
 const downloadManager = new DownloadManager(config);
+const authManager = new AuthManager(config.auth);
 const requestHandler = createRequestHandler({ config, downloadManager });
 const server = http.createServer(requestHandler);
 
@@ -49,7 +51,15 @@ websocketServer.on('connection', (ws: WebSocket) => {
 });
 
 server.on('upgrade', (request, socket, head) => {
-    const ws = handleUpgrade(websocketServer, request, socket, head, config.wsPath);
+    const requestUrl = new URL(request.url ?? '', `http://${request.headers.host}`);
+    const isHistorySocket = requestUrl.pathname === config.historyWsPath;
+    if (isHistorySocket && authManager.isEnabled() && !authManager.isAuthenticated(request)) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+        return;
+    }
+
+    const ws = handleUpgrade(websocketServer, request, socket, head, [config.wsPath, config.historyWsPath]);
     if (ws) {
         websocketServer.emit('connection', ws, request);
     }

--- a/web-version/backend/src/websocket-server.ts
+++ b/web-version/backend/src/websocket-server.ts
@@ -13,7 +13,7 @@ export function handleUpgrade(
     request: IncomingMessage,
     socket: Duplex,
     head: Buffer,
-    pathFilter?: string
+    pathFilter?: string | readonly string[]
 ): WebSocket | null {
     if (request.headers.upgrade?.toLowerCase() !== 'websocket') {
         socket.destroy();
@@ -21,7 +21,8 @@ export function handleUpgrade(
     }
 
     const requestUrl = new URL(request.url ?? '', `http://${request.headers.host}`);
-    if (pathFilter && requestUrl.pathname !== pathFilter) {
+    const pathFilters = typeof pathFilter === 'string' ? [pathFilter] : pathFilter;
+    if (pathFilters && !pathFilters.includes(requestUrl.pathname)) {
         socket.destroy();
         return null;
     }

--- a/web-version/frontend/src/history-page.css
+++ b/web-version/frontend/src/history-page.css
@@ -15,6 +15,12 @@ body {
     color: #0f172a;
 }
 
+body:has(.auth-shell) {
+    background:
+        radial-gradient(circle at top, rgba(79, 70, 229, 0.16), transparent 45%),
+        linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+}
+
 a {
     color: inherit;
     text-decoration: none;
@@ -113,6 +119,26 @@ input {
     color: #0f172a;
 }
 
+.history-shell__account {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.history-shell__account-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-align: right;
+    color: #334155;
+}
+
+.history-shell__account-copy span {
+    font-size: 0.88rem;
+    color: #64748b;
+}
+
 .history-shell__subtitle {
     margin: 4px 0 0;
     color: #475569;
@@ -161,6 +187,64 @@ input {
     border-color: #818cf8;
     color: #4338ca;
     background: rgba(129, 140, 248, 0.08);
+}
+
+.auth-shell {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.auth-card {
+    width: min(100%, 480px);
+    padding: 40px 32px;
+    border-radius: 28px;
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(99, 102, 241, 0.16);
+    box-shadow: 0 32px 80px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(18px);
+}
+
+.auth-card__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: rgba(79, 70, 229, 0.12);
+    color: #4338ca;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.auth-card__title {
+    margin: 18px 0 12px;
+    font-size: clamp(2rem, 6vw, 2.6rem);
+    line-height: 1.05;
+}
+
+.auth-card__description {
+    margin: 0;
+    color: #475569;
+    font-size: 1rem;
+}
+
+.auth-card__error {
+    margin: 18px 0 0;
+    padding: 14px 16px;
+    border-radius: 16px;
+    background: rgba(239, 68, 68, 0.08);
+    color: #b91c1c;
+    border: 1px solid rgba(239, 68, 68, 0.18);
+}
+
+.auth-card__button {
+    width: 100%;
+    margin-top: 24px;
+    padding-block: 14px;
 }
 
 .history-toolbar {

--- a/web-version/frontend/src/history-page/client/components/HistoryApp.tsx
+++ b/web-version/frontend/src/history-page/client/components/HistoryApp.tsx
@@ -843,6 +843,17 @@ export const HistoryApp: FC<HistoryAppProps> = (props) => {
                     <div>
                         <h1 className="history-shell__title">DuckTracker</h1>
                     </div>
+                    {props.viewer ? (
+                        <div className="history-shell__account">
+                            <div className="history-shell__account-copy">
+                                <strong>{props.viewer.displayName}</strong>
+                                {props.viewer.email ? <span>{props.viewer.email}</span> : null}
+                            </div>
+                            <a className="button button--outline" href="/auth/logout">
+                                로그아웃
+                            </a>
+                        </div>
+                    ) : null}
                 </header>
                 <div className="history-toolbar">
                     <div className="history-toolbar__filters">

--- a/web-version/frontend/src/history-page/client/services/historyApi.ts
+++ b/web-version/frontend/src/history-page/client/services/historyApi.ts
@@ -56,7 +56,7 @@ export async function deleteHistory(urlId: string): Promise<void> {
 }
 
 export async function stopDownload(urlId: string): Promise<HistoryItem | null> {
-    const response = await fetch('/stop_download', {
+    const response = await fetch('/history/stop-download', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ urlId })
@@ -70,7 +70,7 @@ export async function stopDownload(urlId: string): Promise<HistoryItem | null> {
 }
 
 export async function resumeDownload(urlId: string): Promise<DownloadRequestResponse | HistoryItem | null> {
-    const response = await fetch('/restart_download', {
+    const response = await fetch('/history/restart-download', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ urlId })

--- a/web-version/frontend/src/history-page/client/types.ts
+++ b/web-version/frontend/src/history-page/client/types.ts
@@ -1,4 +1,4 @@
-import type { FormatOption, HistoryItemBase, HistoryPageViewProps } from '../shared/types.js';
+import type { AuthenticatedViewer, FormatOption, HistoryItemBase, HistoryPageViewProps } from '../shared/types.js';
 
 export interface HistoryItem extends HistoryItemBase {}
 
@@ -14,6 +14,7 @@ export interface RequestDownloadPayload {
 
 export type HistoryPageBootstrap = Omit<HistoryPageViewProps, 'items'> & {
     items: HistoryItem[];
+    viewer?: AuthenticatedViewer | null;
 };
 
 export interface WebSocketMessage {

--- a/web-version/frontend/src/history-page/shared/types.ts
+++ b/web-version/frontend/src/history-page/shared/types.ts
@@ -1,4 +1,5 @@
 export type {
+    AuthenticatedViewer,
     FormatOption,
     AddDownloadDialogMode,
     HistoryItemBase,

--- a/web-version/frontend/src/history-page/types.ts
+++ b/web-version/frontend/src/history-page/types.ts
@@ -1,4 +1,5 @@
 export type {
+    AuthenticatedViewer,
     HistoryItem,
     PaginationState,
     HistoryPageViewProps,

--- a/web-version/shared/src/history-page.d.ts
+++ b/web-version/shared/src/history-page.d.ts
@@ -27,6 +27,11 @@ export interface HistoryItemBase {
 
 export interface HistoryItem extends HistoryItemBase {}
 
+export interface AuthenticatedViewer {
+    displayName: string;
+    email?: string | null;
+}
+
 export interface PaginationState {
     page: number;
     totalPages: number;
@@ -48,4 +53,5 @@ export interface HistoryPageViewProps {
     checkFormatList: boolean;
     selectedStatuses?: string[];
     statusCounts: Record<string, number>;
+    viewer?: AuthenticatedViewer | null;
 }


### PR DESCRIPTION
## Summary
- add an authentik-backed OIDC login flow for the web history dashboard
- protect the browser history routes and authenticated history websocket while keeping extension-compatible endpoints unchanged
- surface login/logout UI state and document the required authentik environment variables

## Testing
- cd web-version && npm run build